### PR TITLE
Add CI pipelines, nightly LKL builds, and documentation

### DIFF
--- a/.github/workflows/build-kbox.yml
+++ b/.github/workflows/build-kbox.yml
@@ -1,0 +1,106 @@
+# Build kbox and run full test suite.
+# Zero root required -- everything runs as an unprivileged user.
+#
+# Parallelism:
+#   unit-tests   -- no LKL, no rootfs, runs immediately
+#   build-kbox   -- fetches LKL, compiles kbox + guest/stress bins, builds rootfs
+#   integration  -- needs build-kbox artifacts, runs integration + stress tests
+#
+# unit-tests and build-kbox run in parallel. integration waits for build-kbox.
+name: Build and Test
+
+on:
+  push:
+    branches: [main, infrastructure]
+  pull_request:
+    branches: [main]
+
+jobs:
+  # ---- Unit tests: no LKL dependency, fast ----
+  unit-tests:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential
+
+      - name: Run unit tests (ASAN/UBSAN)
+        run: make check-unit
+
+  # ---- Build kbox + prepare rootfs ----
+  build-kbox:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential e2fsprogs
+
+      - name: Fetch prebuilt LKL
+        run: ./scripts/fetch-lkl.sh
+
+      - name: Cache rootfs
+        id: cache-rootfs
+        uses: actions/cache@v5
+        with:
+          path: |
+            alpine.ext4
+            deps/
+          key: rootfs-${{ hashFiles('scripts/alpine-sha256.txt', 'scripts/mkrootfs.sh', 'tests/guest/*.c', 'tests/stress/*.c', 'Makefile') }}
+
+      - name: Build kbox (debug + ASAN/UBSAN)
+        run: make -j$(nproc)
+
+      - name: Build guest and stress binaries
+        run: make guest-bins stress-bins
+
+      - name: Build rootfs image
+        if: steps.cache-rootfs.outputs.cache-hit != 'true'
+        run: make rootfs
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: kbox-build
+          retention-days: 1
+          path: |
+            kbox
+            alpine.ext4
+            tests/guest/*-test
+            tests/stress/*
+            !tests/stress/*.c
+            scripts/
+
+  # ---- Integration + stress tests: needs kbox binary + rootfs ----
+  integration-tests:
+    needs: build-kbox
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: kbox-build
+
+      - name: Restore permissions
+        run: |
+          chmod +x kbox
+          chmod +x tests/guest/*-test 2>/dev/null || true
+          chmod +x tests/stress/* 2>/dev/null || true
+          chmod +x scripts/*.sh
+
+      - name: Integration tests
+        run: ./scripts/run-tests.sh ./kbox alpine.ext4
+
+      - name: Stress tests
+        run: ./scripts/run-stress.sh ./kbox alpine.ext4
+        continue-on-error: true

--- a/.github/workflows/build-lkl.yml
+++ b/.github/workflows/build-lkl.yml
@@ -1,0 +1,270 @@
+# Build prebuilt liblkl.a and publish to lkl-nightly release.
+#
+# Schedule: nightly at 03:00 UTC. Skips build if upstream LKL HEAD
+# has not changed since the last successful publish.
+#
+# The lkl-nightly release on sysprog21/kbox always contains exactly
+# one x86_64 and one aarch64 tarball (the latest build).
+name: Build LKL (nightly)
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Force rebuild even if upstream is unchanged'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+env:
+  LKL_UPSTREAM: lkl/linux
+  KBOX_REPO: sysprog21/kbox
+  NIGHTLY_TAG: lkl-nightly
+
+jobs:
+  # ---- Check whether upstream LKL has new commits ----
+  check-upstream:
+    runs-on: ubuntu-24.04
+    outputs:
+      lkl_commit: ${{ steps.head.outputs.commit }}
+      needs_build: ${{ steps.compare.outputs.needs_build }}
+    steps:
+      - name: Get upstream LKL HEAD
+        id: head
+        run: |
+          COMMIT=$(git ls-remote "https://github.com/${{ env.LKL_UPSTREAM }}.git" HEAD | awk '{print $1}')
+          echo "commit=${COMMIT}" >> "$GITHUB_OUTPUT"
+          echo "Upstream LKL HEAD: ${COMMIT}"
+
+      - name: Compare with last published build
+        id: compare
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          FORCE="${{ inputs.force || 'false' }}"
+          if [ "$FORCE" = "true" ]; then
+            echo "needs_build=true" >> "$GITHUB_OUTPUT"
+            echo "Forced rebuild requested."
+            exit 0
+          fi
+
+          # Fetch BUILD_INFO from existing nightly release.
+          LAST_COMMIT=$(gh release view "${{ env.NIGHTLY_TAG }}" \
+            --repo "${{ env.KBOX_REPO }}" \
+            --json body --jq '.body' 2>/dev/null \
+            | grep -oP 'commit=\K[0-9a-f]+' | head -1) || LAST_COMMIT=""
+
+          CURRENT="${{ steps.head.outputs.commit }}"
+          if [ "$LAST_COMMIT" = "$CURRENT" ]; then
+            echo "needs_build=false" >> "$GITHUB_OUTPUT"
+            echo "Upstream unchanged (${CURRENT}). Skipping build."
+          else
+            echo "needs_build=true" >> "$GITHUB_OUTPUT"
+            echo "New upstream commit: ${CURRENT} (was: ${LAST_COMMIT:-none})"
+          fi
+
+  # ---- Build x86_64 and aarch64 in parallel ----
+  build-x86_64:
+    needs: check-upstream
+    if: needs.check-upstream.outputs.needs_build == 'true'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential flex bison bc libelf-dev
+
+      - name: Clone LKL at pinned commit
+        run: |
+          git clone --no-checkout "https://github.com/${{ env.LKL_UPSTREAM }}.git" lkl
+          cd lkl && git checkout ${{ needs.check-upstream.outputs.lkl_commit }}
+
+      - name: Configure LKL
+        working-directory: lkl
+        run: |
+          make ARCH=lkl defconfig
+          ./scripts/config --enable CONFIG_DEVTMPFS
+          ./scripts/config --enable CONFIG_DEVTMPFS_MOUNT
+          ./scripts/config --enable CONFIG_DEVPTS_FS
+          ./scripts/config --enable CONFIG_DEBUG_INFO
+          ./scripts/config --set-val CONFIG_DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT y
+          ./scripts/config --enable CONFIG_GDB_SCRIPTS
+          ./scripts/config --enable CONFIG_SCHED_DEBUG
+          ./scripts/config --enable CONFIG_PROC_SYSCTL
+          ./scripts/config --enable CONFIG_PRINTK
+          ./scripts/config --enable CONFIG_TRACEPOINTS
+          ./scripts/config --enable CONFIG_FTRACE
+          ./scripts/config --enable CONFIG_DEBUG_FS
+          ./scripts/config --disable CONFIG_MODULES
+          ./scripts/config --disable CONFIG_SOUND
+          ./scripts/config --disable CONFIG_USB_SUPPORT
+          ./scripts/config --disable CONFIG_INPUT
+          ./scripts/config --disable CONFIG_NFS_FS
+          ./scripts/config --disable CONFIG_CIFS
+          make ARCH=lkl olddefconfig
+
+      - name: Build LKL
+        working-directory: lkl
+        run: make ARCH=lkl -j$(nproc)
+
+      - name: Verify symbols
+        working-directory: lkl
+        run: |
+          test -f tools/lkl/liblkl.a || { echo "liblkl.a not found"; exit 1; }
+          for sym in lkl_init lkl_start_kernel lkl_cleanup lkl_syscall \
+                     lkl_strerror lkl_disk_add lkl_mount_dev \
+                     lkl_host_ops lkl_dev_blk_ops; do
+            if ! nm tools/lkl/liblkl.a 2>/dev/null | awk -v s="$sym" \
+                '$3 == s && $2 ~ /^[TtDdBbRr]$/ {found=1} END {exit !found}'; then
+              echo "MISSING symbol: ${sym}"; exit 1
+            fi
+          done
+
+      - name: Package
+        working-directory: lkl
+        run: |
+          mkdir -p pkg
+          cp tools/lkl/liblkl.a pkg/
+          cp tools/lkl/include/lkl.h pkg/ 2>/dev/null || true
+          cp tools/lkl/include/lkl/autoconf.h pkg/ 2>/dev/null || true
+          cp scripts/gdb/vmlinux-gdb.py pkg/ 2>/dev/null || true
+          echo "commit=$(git rev-parse HEAD)" > pkg/BUILD_INFO
+          echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> pkg/BUILD_INFO
+          echo "arch=x86_64" >> pkg/BUILD_INFO
+          cd pkg && sha256sum ./* > sha256sums.txt
+          cd .. && tar czf liblkl-x86_64.tar.gz -C pkg .
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: lkl-x86_64
+          path: lkl/liblkl-x86_64.tar.gz
+          retention-days: 3
+
+  build-aarch64:
+    needs: check-upstream
+    if: needs.check-upstream.outputs.needs_build == 'true'
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential flex bison bc libelf-dev
+
+      - name: Clone LKL at pinned commit
+        run: |
+          git clone --no-checkout "https://github.com/${{ env.LKL_UPSTREAM }}.git" lkl
+          cd lkl && git checkout ${{ needs.check-upstream.outputs.lkl_commit }}
+
+      - name: Configure LKL
+        working-directory: lkl
+        run: |
+          make ARCH=lkl defconfig
+          ./scripts/config --enable CONFIG_DEVTMPFS
+          ./scripts/config --enable CONFIG_DEVTMPFS_MOUNT
+          ./scripts/config --enable CONFIG_DEVPTS_FS
+          ./scripts/config --enable CONFIG_DEBUG_INFO
+          ./scripts/config --set-val CONFIG_DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT y
+          ./scripts/config --enable CONFIG_GDB_SCRIPTS
+          ./scripts/config --enable CONFIG_SCHED_DEBUG
+          ./scripts/config --enable CONFIG_PROC_SYSCTL
+          ./scripts/config --enable CONFIG_PRINTK
+          ./scripts/config --enable CONFIG_TRACEPOINTS
+          ./scripts/config --enable CONFIG_FTRACE
+          ./scripts/config --enable CONFIG_DEBUG_FS
+          ./scripts/config --disable CONFIG_MODULES
+          ./scripts/config --disable CONFIG_SOUND
+          ./scripts/config --disable CONFIG_USB_SUPPORT
+          ./scripts/config --disable CONFIG_INPUT
+          ./scripts/config --disable CONFIG_NFS_FS
+          ./scripts/config --disable CONFIG_CIFS
+          make ARCH=lkl olddefconfig
+
+      - name: Build LKL
+        working-directory: lkl
+        run: make ARCH=lkl -j$(nproc)
+
+      - name: Verify symbols
+        working-directory: lkl
+        run: |
+          test -f tools/lkl/liblkl.a || { echo "liblkl.a not found"; exit 1; }
+          for sym in lkl_init lkl_start_kernel lkl_cleanup lkl_syscall \
+                     lkl_strerror lkl_disk_add lkl_mount_dev \
+                     lkl_host_ops lkl_dev_blk_ops; do
+            if ! nm tools/lkl/liblkl.a 2>/dev/null | awk -v s="$sym" \
+                '$3 == s && $2 ~ /^[TtDdBbRr]$/ {found=1} END {exit !found}'; then
+              echo "MISSING symbol: ${sym}"; exit 1
+            fi
+          done
+
+      - name: Package
+        working-directory: lkl
+        run: |
+          mkdir -p pkg
+          cp tools/lkl/liblkl.a pkg/
+          cp tools/lkl/include/lkl.h pkg/ 2>/dev/null || true
+          cp tools/lkl/include/lkl/autoconf.h pkg/ 2>/dev/null || true
+          cp scripts/gdb/vmlinux-gdb.py pkg/ 2>/dev/null || true
+          echo "commit=$(git rev-parse HEAD)" > pkg/BUILD_INFO
+          echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> pkg/BUILD_INFO
+          echo "arch=aarch64" >> pkg/BUILD_INFO
+          cd pkg && sha256sum ./* > sha256sums.txt
+          cd .. && tar czf liblkl-aarch64.tar.gz -C pkg .
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: lkl-aarch64
+          path: lkl/liblkl-aarch64.tar.gz
+          retention-days: 3
+
+  # ---- Publish: replace lkl-nightly release with latest artifacts ----
+  publish-nightly:
+    needs: [check-upstream, build-x86_64, build-aarch64]
+    if: needs.check-upstream.outputs.needs_build == 'true'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: dist/
+          merge-multiple: true
+
+      - name: Delete old nightly release (if exists)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release delete "${{ env.NIGHTLY_TAG }}" \
+            --repo "${{ env.KBOX_REPO }}" \
+            --yes --cleanup-tag 2>/dev/null || true
+
+      - name: Create nightly release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          LKL_COMMIT="${{ needs.check-upstream.outputs.lkl_commit }}"
+          BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+          cat > /tmp/release-notes.md <<EOF
+          Nightly prebuilt liblkl.a for kbox.
+
+          commit=${LKL_COMMIT}
+          date=${BUILD_DATE}
+          upstream=https://github.com/${{ env.LKL_UPSTREAM }}/commit/${LKL_COMMIT}
+
+          Contains: liblkl-x86_64.tar.gz, liblkl-aarch64.tar.gz
+          Each tarball includes: liblkl.a, lkl.h, autoconf.h, vmlinux-gdb.py,
+          BUILD_INFO, sha256sums.txt
+          EOF
+
+          gh release create "${{ env.NIGHTLY_TAG }}" \
+            --repo "${{ env.KBOX_REPO }}" \
+            --title "LKL nightly (${BUILD_DATE})" \
+            --notes-file /tmp/release-notes.md \
+            --prerelease \
+            dist/liblkl-x86_64.tar.gz \
+            dist/liblkl-aarch64.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,10 @@ ROOTFS       = alpine.ext4
 
 .PHONY: all clean check check-unit check-integration check-stress guest-bins stress-bins rootfs fetch-lkl install-hooks
 
-all: .git/hooks/pre-commit $(TARGET)
+all: $(TARGET)
+ifneq ($(wildcard .git),)
+all: | .git/hooks/pre-commit
+endif
 
 $(TARGET): $(OBJS) | $(LKL_LIB)
 	$(CC) $(LDFLAGS) -o $@ $(OBJS) $(LDLIBS)
@@ -107,9 +110,9 @@ $(TARGET): $(OBJS) | $(LKL_LIB)
 %.o: %.c
 	$(CC) $(CFLAGS) -c -o $@ $<
 
-# Auto-install git hooks on first build.
+# Auto-install git hooks on first build (skipped in worktrees where .git is a file).
 .git/hooks/pre-commit: scripts/pre-commit.hook
-	@$(MAKE) -s install-hooks
+	@if [ -d .git/hooks ]; then $(MAKE) -s install-hooks; fi
 
 # Auto-fetch LKL if missing
 $(LKL_LIB):
@@ -158,15 +161,20 @@ $(ROOTFS): scripts/mkrootfs.sh scripts/alpine-sha256.txt $(GUEST_BINS) $(STRESS_
 
 # ---- Utilities ----
 
+# Fetch LKL from nightly release if not cached locally.
+# To force re-download: rm -rf lkl-x86_64 && make fetch-lkl
 fetch-lkl:
 	./scripts/fetch-lkl.sh
 
 # Install git hooks from scripts/*.hook into .git/hooks/.
+# Skips hooks that already exist (preserves user customizations).
 install-hooks:
 	@for hook in scripts/*.hook; do \
 	    name=$$(basename "$$hook" .hook); \
-	    ln -sf ../../"$$hook" .git/hooks/"$$name"; \
-	    echo "Installed $$name hook"; \
+	    if [ ! -e .git/hooks/"$$name" ] && [ ! -L .git/hooks/"$$name" ]; then \
+	        ln -s ../../"$$hook" .git/hooks/"$$name"; \
+	        echo "Installed $$name hook"; \
+	    fi; \
 	done
 
 clean:

--- a/docs/lkl-api-surface.md
+++ b/docs/lkl-api-surface.md
@@ -1,0 +1,124 @@
+# LKL API Surface Used by kbox
+
+This document identifies the LKL symbols kbox depends on, their purpose,
+and known ABI considerations. Use this to verify that a given liblkl.a
+build is compatible with kbox.
+
+## Required Symbols
+
+These must be exported by liblkl.a. The build-lkl CI workflow verifies
+each one via `nm`.
+
+### Core Lifecycle
+
+| Symbol | Type | Purpose |
+|--------|------|---------|
+| `lkl_init` | function | Initialize LKL host operations |
+| `lkl_start_kernel` | function | Boot the in-process kernel |
+| `lkl_cleanup` | function | Shut down the kernel |
+| `lkl_strerror` | function | Convert LKL error code to string |
+
+### Syscall Interface
+
+| Symbol | Type | Purpose |
+|--------|------|---------|
+| `lkl_syscall` | function | Raw syscall dispatch (nr + params array) |
+
+All 64 `kbox_lkl_*` wrappers in `lkl-wrap.c` route through a single
+`lkl_syscall6()` helper that packs 6 args into the params array and
+calls `lkl_syscall()`. This is the only runtime entry point into the
+kernel.
+
+### Block Device
+
+| Symbol | Type | Purpose |
+|--------|------|---------|
+| `lkl_disk_add` | function | Register ext4 image as virtual block device |
+| `lkl_mount_dev` | function | Mount a disk partition by ID |
+
+### Extern Globals
+
+| Symbol | Type | Purpose |
+|--------|------|---------|
+| `lkl_host_ops` | data | Host operation callbacks (threading, memory, etc.) |
+| `lkl_dev_blk_ops` | data | Block device operation callbacks |
+
+kbox takes the address of these and passes them to `lkl_init()` and
+`lkl_disk_add()` respectively. The exact struct layouts are opaque --
+kbox never reads or writes their fields directly.
+
+## ABI Contract
+
+kbox declares its own LKL FFI in `include/kbox/lkl-wrap.h` rather than
+including LKL's header tree. This means:
+
+1. kbox compiles without `lkl.h` or `lkl/autoconf.h`.
+2. The binding is purely at the symbol level -- function signatures must
+   match but header compatibility is not required.
+3. Any change to the signatures of the 9 symbols above is a breaking
+   change for kbox.
+
+### struct lkl_disk
+
+kbox declares a minimal `struct lkl_disk` with three fields:
+```c
+struct lkl_disk {
+    void *dev;
+    int fd;
+    void *ops;
+};
+```
+This must match the beginning of LKL's actual struct. If LKL reorders
+or adds fields before `ops`, kbox breaks silently.
+
+### Syscall Number ABI
+
+LKL may use x86_64-native or asm-generic syscall numbers depending on
+the build. kbox resolves this at compile time via `probe.c`, which
+detects the ABI by calling known syscalls and comparing results. The
+`struct kbox_sysnrs` in `syscall-nr.h` stores the detected numbers.
+
+### struct stat ABI
+
+LKL always uses the asm-generic stat layout (128 bytes). The x86_64
+host uses a different layout (144 bytes). kbox defines `struct
+kbox_lkl_stat` to match the asm-generic layout and converts to host
+format via `kbox_lkl_stat_to_host()` before writing to tracee memory.
+
+## Rust Codebase Comparison
+
+The original Rust implementation (reference, never committed to this
+repo) used the same core LKL symbols via FFI bindings generated from
+`lkl.h`. The C rewrite eliminates the FFI layer entirely -- it links
+directly against the same symbols.
+
+Key differences from the Rust approach:
+
+| Aspect | Rust | C |
+|--------|------|---|
+| LKL header dependency | `lkl.h` via bindgen | None (manual declarations) |
+| Syscall dispatch | detect_sysnrs() runtime probing | Compile-time constants + probe.c |
+| stat handling | Host struct stat (buggy) | kbox_lkl_stat + field-by-field conversion |
+| Build complexity | Cargo + bindgen + cc crate | Single Makefile, static link |
+| virtiofsd | Required (host mode) | Eliminated (host mode deferred) |
+
+No LKL symbols were added or removed between the Rust and C
+implementations. The API surface is identical -- what changed is how
+kbox consumes it.
+
+## Verification
+
+Run this on a liblkl.a to verify compatibility:
+
+```bash
+#!/bin/sh
+for sym in lkl_init lkl_start_kernel lkl_cleanup lkl_syscall \
+           lkl_strerror lkl_disk_add lkl_mount_dev \
+           lkl_host_ops lkl_dev_blk_ops; do
+    if nm liblkl.a 2>/dev/null | grep -q " [TDBRdb] ${sym}$"; then
+        printf "  %-24s OK\n" "$sym"
+    else
+        printf "  %-24s MISSING\n" "$sym"
+    fi
+done
+```

--- a/docs/lkl-threading-modes.md
+++ b/docs/lkl-threading-modes.md
@@ -1,0 +1,97 @@
+# LKL Threading Modes and Impact on kbox
+
+LKL supports two host threading configurations. This document describes
+each mode, their behavioral differences, and the impact on the kbox
+supervisor design.
+
+## Single-Threaded Mode (Current Default)
+
+One host thread runs all kernel tasks via LKL's internal cooperative
+scheduler. The kernel boots with `lkl_start_kernel()` and all subsequent
+`lkl_syscall()` calls execute on the calling thread.
+
+Characteristics:
+- A blocking LKL syscall (e.g., `read` on a pipe with no data) blocks
+  ALL kernel activity. No other kernel task can run until the syscall
+  returns or is interrupted.
+- Kernel-internal scheduling is serialized. LKL's scheduler picks the
+  next task cooperatively, but all execution happens on one host thread.
+- Nondeterminism still exists from: host scheduling of the supervisor
+  thread, signals, clocks, `getrandom()`, and seccomp notification
+  ordering.
+- GDB debugging is simpler: one thread of kernel execution, reproducible
+  ordering of kernel-internal events.
+
+Why this is the right default for kbox:
+- The supervisor's poll loop (seccomp notification FD) runs on a
+  separate host thread from LKL. The two threads synchronize via
+  `lkl_syscall()` calls -- the supervisor thread enters LKL to perform
+  filesystem/identity operations, then returns to the poll loop.
+- Concurrent kernel entry is safe even in single-threaded mode because
+  LKL's `lkl_host_ops` mutex serializes all kernel entry points.
+  `lkl_syscall()` acquires the host semaphore before entering kernel
+  code and releases it on return. This means the supervisor thread and
+  any LKL-internal timer/softirq threads never execute kernel code
+  concurrently -- they are serialized by the host mutex. There is no
+  data race.
+- kbox never calls blocking LKL syscalls from the supervisor. All LKL
+  calls are non-blocking filesystem operations (openat, read, stat,
+  getdents, etc.) on the ext4 image.
+- Single-threaded mode eliminates SMP race conditions inside the kernel,
+  which is irrelevant for kbox's use case (filesystem serving, not
+  concurrent kernel driver testing).
+
+## Multi-Threaded Mode
+
+Multiple host pthreads can enter kernel code concurrently. LKL creates
+real kernel threads backed by host pthreads. Spinlocks and RCU operate
+with real contention.
+
+Characteristics:
+- True concurrent execution of kernel code paths. Multiple `lkl_syscall()`
+  calls from different host threads execute in parallel inside the kernel.
+- Real spinlock contention, RCU grace periods with actual read-side
+  concurrency, and scheduler load balancing (if configured for SMP).
+- Requires `lkl_host_ops` to provide proper mutex/semaphore/thread
+  primitives. LKL's default `posix-host.c` implements these via pthreads.
+- Higher fidelity for concurrency experiments but harder to debug.
+
+When multi-threaded mode matters:
+- Educational labs studying lock contention, RCU, or SMP scheduling.
+- Testing concurrent filesystem operations under real kernel locking.
+- Performance benchmarking of kernel code paths under contention.
+
+Impact on kbox supervisor:
+- The supervisor's poll loop and LKL syscall calls would need proper
+  synchronization if multiple supervisor threads entered LKL
+  concurrently. The current single-supervisor-thread design avoids this.
+- The virtual FD table (`fd_table.c`) is not thread-safe. If kbox ever
+  supports concurrent dispatch from multiple supervisor threads, the FD
+  table needs locking.
+- LKL's `posix-host.c` leaks semaphores on shutdown in both modes.
+  `ASAN_OPTIONS=detect_leaks=0` suppresses the false positive.
+
+## Configuration
+
+LKL's threading mode is determined at build time by the kernel
+configuration and at runtime by `lkl_host_ops`. The default
+`posix-host.c` host operations support both modes.
+
+To force single-threaded behavior:
+- Boot with kernel command line containing `lkl.cpus=1` (if supported
+  by the LKL build).
+- Or ensure only one host thread ever calls `lkl_syscall()`.
+
+kbox currently does the latter implicitly: only the supervisor thread
+calls LKL, and it does so sequentially (no concurrent LKL calls).
+
+## Recommendation
+
+Single-threaded mode for MVP and all Groups A-D. Multi-threaded mode
+is only needed for Group E educational labs that study kernel concurrency
+primitives (Lab 09: Locking and RCU). Enabling it requires:
+1. Thread-safe FD table (add pthread_mutex or use atomic operations).
+2. Audit all supervisor state for thread safety.
+3. Explicit `--lkl-threads=N` CLI flag (default 1).
+
+This is post-MVP work and should not gate any current deliverables.

--- a/include/kbox/lkl-wrap.h
+++ b/include/kbox/lkl-wrap.h
@@ -8,7 +8,14 @@
 #include "kbox/syscall-nr.h"
 
 /*
- * Opaque LKL types -- we only ever pass pointers.
+ * LKL disk descriptor.  This must match the prefix of LKL's struct lkl_disk
+ * (defined in tools/lkl/include/lkl.h).  We declare it here rather than
+ * including the full LKL header tree.
+ *
+ * WARNING: if upstream LKL reorders or adds fields before 'ops', kbox will
+ * silently corrupt the struct.  The CI build-lkl workflow verifies symbol
+ * presence but cannot detect layout changes.  When upgrading the pinned LKL
+ * commit, manually verify this struct matches upstream.
  */
 struct lkl_disk {
     void *dev;

--- a/scripts/fetch-lkl.sh
+++ b/scripts/fetch-lkl.sh
@@ -1,126 +1,120 @@
 #!/bin/sh
 # SPDX-License-Identifier: MIT
-# Fetch prebuilt liblkl.a from GitHub Releases or Actions artifacts.
+# Fetch prebuilt liblkl.a from the lkl-nightly release on sysprog21/kbox.
 #
 # Usage: ./scripts/fetch-lkl.sh [ARCH]
-#   ARCH defaults to x86_64.  Override LKL_DIR to change output directory.
+#   ARCH defaults to the host architecture (x86_64 or aarch64).
+#   Override LKL_DIR to change output directory.
 #
 # Download order:
-#   1. GitHub Releases (curl, no auth needed)
-#   2. GitHub CLI (gh) Actions artifacts
+#   1. lkl-nightly release on sysprog21/kbox (curl, no auth)
+#   2. GitHub CLI (gh) -- same release, authenticated
 #   3. Manual instructions
 
 set -eu
 
-ARCH="${1:-x86_64}"
+# Auto-detect architecture.
+case "${1:-$(uname -m)}" in
+x86_64 | amd64) ARCH="x86_64" ;;
+aarch64 | arm64) ARCH="aarch64" ;;
+*)
+	echo "error: unsupported architecture: ${1:-$(uname -m)}" >&2
+	exit 1
+	;;
+esac
+
 LKL_DIR="${LKL_DIR:-lkl-${ARCH}}"
-REPO="${KBOX_REPO:-lkl/linux}"
+REPO="${KBOX_REPO:-sysprog21/kbox}"
+NIGHTLY_TAG="${KBOX_LKL_TAG:-lkl-nightly}"
 ASSET="liblkl-${ARCH}.tar.gz"
 SHA256_FILE="scripts/lkl-sha256.txt"
 
 die() {
-    echo "error: $*" >&2
-    exit 1
+	echo "error: $*" >&2
+	exit 1
 }
 
 mkdir -p "$LKL_DIR"
 
 # Already present?
 if [ -f "${LKL_DIR}/liblkl.a" ]; then
-    echo "OK: ${LKL_DIR}/liblkl.a (already exists)"
-    exit 0
+	echo "OK: ${LKL_DIR}/liblkl.a (already exists)"
+	exit 0
 fi
 
 # --- Method 1: GitHub Releases (curl, no auth) ---
 try_release() {
-    if ! command -v curl > /dev/null 2>&1; then
-        return 1
-    fi
+	if ! command -v curl >/dev/null 2>&1; then
+		return 1
+	fi
 
-    echo "Querying latest lkl-v* release from ${REPO}..."
-    TAG=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases" \
-        | grep -o '"tag_name": *"lkl-v[^"]*"' \
-        | head -1 \
-        | sed 's/.*"lkl-v/lkl-v/; s/"//' 2> /dev/null) || return 1
+	URL="https://github.com/${REPO}/releases/download/${NIGHTLY_TAG}/${ASSET}"
+	echo "Downloading ${URL}..."
+	curl -fSL -o "${LKL_DIR}/${ASSET}" "$URL" || return 1
 
-    if [ -z "$TAG" ]; then
-        echo "No lkl-v* release tag found."
-        return 1
-    fi
+	# Verify SHA256 if pinfile has an entry for this asset.
+	if [ -f "$SHA256_FILE" ]; then
+		EXPECTED=$(grep "$ASSET" "$SHA256_FILE" | awk '{print $1}')
+		if [ -n "$EXPECTED" ]; then
+			ACTUAL=$(sha256sum "${LKL_DIR}/${ASSET}" | awk '{print $1}')
+			if [ "$ACTUAL" != "$EXPECTED" ]; then
+				rm -f "${LKL_DIR}/${ASSET}"
+				die "SHA256 mismatch for ${ASSET}"
+			fi
+			echo "SHA256 verified."
+		fi
+	fi
 
-    URL="https://github.com/${REPO}/releases/download/${TAG}/${ASSET}"
-    echo "Downloading ${URL}..."
-    curl -fSL -o "${LKL_DIR}/${ASSET}" "$URL" || return 1
-
-    # Verify SHA256 if pinfile exists.
-    if [ -f "$SHA256_FILE" ]; then
-        EXPECTED=$(grep "$ASSET" "$SHA256_FILE" | awk '{print $1}')
-        if [ -n "$EXPECTED" ]; then
-            ACTUAL=$(sha256sum "${LKL_DIR}/${ASSET}" | awk '{print $1}')
-            if [ "$ACTUAL" != "$EXPECTED" ]; then
-                rm -f "${LKL_DIR}/${ASSET}"
-                die "SHA256 mismatch for ${ASSET}"
-            fi
-            echo "SHA256 verified."
-        fi
-    fi
-
-    tar xzf "${LKL_DIR}/${ASSET}" -C "$LKL_DIR"
-    rm -f "${LKL_DIR}/${ASSET}"
-    return 0
+	tar xzf "${LKL_DIR}/${ASSET}" -C "$LKL_DIR"
+	rm -f "${LKL_DIR}/${ASSET}"
+	return 0
 }
 
-# --- Method 2: gh CLI (Actions artifacts) ---
+# --- Method 2: gh CLI ---
 try_gh() {
-    if ! command -v gh > /dev/null 2>&1; then
-        return 1
-    fi
+	if ! command -v gh >/dev/null 2>&1; then
+		return 1
+	fi
 
-    echo "Fetching liblkl.a (${ARCH}) via gh CLI..."
-    ARTIFACT_NAME="lkl-${ARCH}"
+	echo "Fetching ${ASSET} via gh CLI..."
+	TMPDIR=$(mktemp -d)
+	gh release download "$NIGHTLY_TAG" \
+		--repo "$REPO" \
+		--pattern "$ASSET" \
+		--dir "$TMPDIR" 2>/dev/null || {
+		rm -rf "$TMPDIR"
+		return 1
+	}
 
-    gh run download --repo "$REPO" \
-        --name "$ARTIFACT_NAME" \
-        --dir "$LKL_DIR" 2> /dev/null && return 0
-
-    echo "Direct download failed. Trying latest workflow run..."
-    RUN_ID=$(gh run list --repo "$REPO" \
-        --workflow "push.yml" \
-        --status completed \
-        --limit 1 \
-        --json databaseId \
-        --jq '.[0].databaseId' 2> /dev/null) || return 1
-
-    gh run download "$RUN_ID" \
-        --repo "$REPO" \
-        --name "$ARTIFACT_NAME" \
-        --dir "$LKL_DIR" || return 1
-
-    return 0
+	tar xzf "${TMPDIR}/${ASSET}" -C "$LKL_DIR"
+	rm -rf "$TMPDIR"
+	return 0
 }
 
 # Try methods in order.
 if try_release; then
-    :
+	:
 elif try_gh; then
-    :
+	:
 else
-    cat >&2 << EOF
+	cat >&2 <<EOF
 Cannot fetch liblkl.a automatically.
 
-Manual download options:
-  1. GitHub Releases: check https://github.com/${REPO}/releases
-     for lkl-v* tags, download ${ASSET}, extract into ${LKL_DIR}/
-  2. GitHub CLI: install gh from https://cli.github.com/
-     then re-run this script
-  3. Build from source: see https://github.com/${REPO}
+Manual download:
+  https://github.com/${REPO}/releases/tag/${NIGHTLY_TAG}
+  Download ${ASSET}, then: tar xzf ${ASSET} -C ${LKL_DIR}/
+
+Or build from source:
+  git clone https://github.com/lkl/linux.git
+  cd linux && make ARCH=lkl defconfig && make ARCH=lkl -j\$(nproc)
+  cp tools/lkl/liblkl.a ${LKL_DIR}/
 
 EOF
-    exit 1
+	exit 1
 fi
 
 if [ -f "${LKL_DIR}/liblkl.a" ]; then
-    echo "OK: ${LKL_DIR}/liblkl.a"
+	echo "OK: ${LKL_DIR}/liblkl.a"
 else
-    die "Download succeeded but liblkl.a not found in ${LKL_DIR}/"
+	die "Download succeeded but liblkl.a not found in ${LKL_DIR}/"
 fi

--- a/scripts/lsan-suppressions.txt
+++ b/scripts/lsan-suppressions.txt
@@ -1,0 +1,4 @@
+# LSAN suppressions for known LKL leaks.
+# LKL's posix-host.c leaks semaphores on shutdown.
+leak:posix-host
+leak:lkl_host_ops

--- a/scripts/run-stress.sh
+++ b/scripts/run-stress.sh
@@ -8,8 +8,12 @@
 
 set -eu
 
-# LKL's posix-host.c leaks semaphores on shutdown; suppress LSAN.
-export ASAN_OPTIONS="${ASAN_OPTIONS:-}${ASAN_OPTIONS:+:}detect_leaks=0"
+# LKL's posix-host.c leaks semaphores on shutdown.
+# Suppress via LSAN_OPTIONS suppression file (see scripts/lsan-suppressions.txt)
+# rather than blanket detect_leaks=0, so kbox's own leaks are still caught.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SUPP="suppressions=${SCRIPT_DIR}/lsan-suppressions.txt"
+export LSAN_OPTIONS="${LSAN_OPTIONS:+${LSAN_OPTIONS}:}${SUPP}"
 
 KBOX="${1:-./kbox}"
 ROOTFS="${2:-rootfs.ext4}"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -9,8 +9,12 @@
 
 set -eu
 
-# LKL's posix-host.c leaks semaphores on shutdown; suppress LSAN.
-export ASAN_OPTIONS="${ASAN_OPTIONS:-}${ASAN_OPTIONS:+:}detect_leaks=0"
+# LKL's posix-host.c leaks semaphores on shutdown.
+# Suppress via LSAN_OPTIONS suppression file (see scripts/lsan-suppressions.txt)
+# rather than blanket detect_leaks=0, so kbox's own leaks are still caught.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SUPP="suppressions=${SCRIPT_DIR}/lsan-suppressions.txt"
+export LSAN_OPTIONS="${LSAN_OPTIONS:+${LSAN_OPTIONS}:}${SUPP}"
 
 KBOX="${1:-./kbox}"
 ROOTFS="${2:-alpine.ext4}"


### PR DESCRIPTION
Nightly workflow (build-lkl.yml) builds liblkl.a for x86_64 and aarch64 in parallel, checks upstream lkl/linux HEAD to skip redundant rebuilds, and publishes to the lkl-nightly release on sysprog21/kbox with delete-then-create semantics.

Build-and-test workflow (build-kbox.yml) splits unit tests from integration tests for parallelism: unit tests run immediately (no LKL dependency) while the build job fetches LKL, compiles, and prepares the rootfs.

fetch-lkl.sh now fetches from sysprog21/kbox lkl-nightly release instead of querying lkl/linux releases. Auto-detects host arch.

Also adds LKL API surface doc, threading mode analysis, LSAN suppression file for known LKL leaks, and ABI warning on manually-declared struct lkl_disk.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CI for build/test and a nightly LKL builder that publishes prebuilt `liblkl.a` for x86_64 and aarch64. Speeds up testing, pins a consistent LKL, and documents our LKL interface and threading model.

- **New Features**
  - Nightly LKL build: builds `liblkl.a` for x86_64/aarch64, skips if upstream `lkl/linux` HEAD unchanged, verifies required symbols, publishes to `lkl-nightly` on `sysprog21/kbox`.
  - CI for kbox: unit tests run in parallel with build; integration + stress tests run on artifacts; ASAN/UBSAN enabled with LSAN suppressions.
  - `fetch-lkl.sh`: pulls from `sysprog21/kbox` `lkl-nightly`, auto-detects host arch, optional SHA256 check.
  - Makefile: auto-installs git hooks via `install-hooks` (wired into `all`); keeps auto-fetch of LKL.
  - Docs: LKL API surface and threading modes added; ABI warning on manual `struct lkl_disk`.

- **Migration**
  - CI runs on pushes to `main`/`infrastructure` and nightly at 03:00 UTC; no action needed.
  - Local builds unchanged; to refresh LKL: remove `lkl-<arch>` and run `make fetch-lkl`.
  - For local ASAN runs, set `LSAN_OPTIONS=suppressions=scripts/lsan-suppressions.txt`.
  - When upgrading LKL, verify `struct lkl_disk` layout against upstream.

<sup>Written for commit ae560aeb8e9872ba6060c0888e0043fb3d029674. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

