### PR TITLE
Improve cross-compilation argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ CFLAGS   ?=
 LDFLAGS  ?=
 BUILD    ?= debug
 
+ARCH ?= $(shell uname -m)
+
 CFLAGS  += -std=gnu11 -D_GNU_SOURCE -Wall -Wextra -Wpedantic -Wshadow
 CFLAGS  += -Wno-unused-parameter
 CFLAGS  += -Iinclude -Isrc
@@ -19,7 +21,7 @@ else
 endif
 
 # LKL library
-LKL_DIR  ?= lkl-x86_64
+LKL_DIR  ?= lkl-$(ARCH)
 LKL_LIB   = $(LKL_DIR)/liblkl.a
 
 LDFLAGS += -L$(LKL_DIR) -L$(LKL_DIR)/lib
@@ -129,7 +131,7 @@ $(TARGET): $(OBJS) | $(LKL_LIB)
 # Auto-fetch LKL if missing
 $(LKL_LIB):
 	@echo "LKL library not found at $(LKL_DIR). Fetching..."
-	./scripts/fetch-lkl.sh
+	./scripts/fetch-lkl.sh $(ARCH)
 
 # Auto-fetch minislirp if missing (shallow clone, no submodule).
 # $(wildcard) evaluates at parse time, so if minislirp has not been
@@ -188,14 +190,14 @@ $(STRESS_DIR)/%: $(STRESS_DIR)/%.c
 rootfs: $(ROOTFS)
 
 $(ROOTFS): scripts/mkrootfs.sh scripts/alpine-sha256.txt $(GUEST_BINS) $(STRESS_BINS)
-	./scripts/mkrootfs.sh
+	ALPINE_ARCH=$(ARCH) ./scripts/mkrootfs.sh
 
 # ---- Utilities ----
 
 # Fetch LKL from nightly release if not cached locally.
 # To force re-download: rm -rf lkl-x86_64 && make fetch-lkl
 fetch-lkl:
-	./scripts/fetch-lkl.sh
+	./scripts/fetch-lkl.sh $(ARCH)
 
 # Install git hooks from scripts/*.hook into .git/hooks/.
 # Skips hooks that already exist (preserves user customizations).

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ make BUILD=release          # release build
 make KBOX_HAS_WEB=1         # enable web-based kernel observatory
 ```
 
+For cross-compilation, use `ARCH` to specify the target architecture and `CC` for the toolchain.
+
+```bash
+make BUILD=release ARCH=aarch64 CC=aarch64-linux-gnu-gcc
+```
+
 LKL is fetched automatically from the [nightly pre-release](https://github.com/sysprog21/kbox/releases/tag/lkl-nightly) on first build. Pre-built binaries are available for both x86_64 and aarch64. To use a custom LKL:
 
 ```bash
@@ -92,10 +98,14 @@ make FORCE_LKL_BUILD=1      # force a from-source LKL rebuild
 
 ## Quick start
 
-Build a test rootfs image (requires `e2fsprogs`, no root needed). The script auto-detects the host architecture and downloads the matching Alpine minirootfs:
+Build a test rootfs image (requires `e2fsprogs`, no root needed). By default, the script auto-detects the host architecture and downloads the matching Alpine minirootfs. The `ARCH` variable can be specified to build an image for the target architecture:
 
 ```bash
-make rootfs                 # creates alpine.ext4
+# Create alpine.ext4 for the host architecture
+make rootfs
+
+# Create alpine.ext4 for aarch64
+make ARCH=aarch64 CC=aarch64-linux-gnu-gcc rootfs
 ```
 
 ## Usage


### PR DESCRIPTION
Previously, the arguments for cross-compilation were not intuitive, requiring users to read the build script to figure them out.

For example, the aarch target has to be built with the following commands, which is exhausting:
```shell
$ scripts/fetch-lkl.sh aarch64
$ make LKL_DIR=`pwd`/lkl-aarch64 CC=aarch64-linux-gnu-gcc BUILD=release
$ make ALPINE_ARCH=aarch64 rootfs
```

This changes it to a simple `ARCH` argument, and the same thing can be done by the following commands:
```shell
$ make ARCH=aarch64 CC=aarch64-linux-gnu-gcc
$ make ARCH=aarch64 CC=aarch64-linux-gnu-gcc rootfs
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified cross-compilation by adding a single `ARCH` make variable that defaults to `uname -m` and flows through build, LKL fetch, and rootfs. Building targets like `aarch64` is now a one-liner; host builds are unchanged.

- **New Features**
  - Plumbed `ARCH` into `LKL_DIR`, `fetch-lkl.sh` (including the `fetch-lkl` target), and `ALPINE_ARCH` for `mkrootfs.sh`.
  - Updated `README.md` with `ARCH`/`CC` examples and Quick Start notes for host vs target rootfs.

<sup>Written for commit 535544fe25c86e7b3bf2564a53ada975d723e305. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

