### PR TITLE
Add make indent and enforce consistent code style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# Top-level EditorConfig file
+root = true
+
+# Shell script-specific settings
+[*.sh]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+function_next_line = true
+switch_case_indent = true
+space_redirects = true
+binary_next_line = true

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ ROOTFS       = alpine.ext4
 
 # ---- Top-level targets ----
 
-.PHONY: all clean check check-unit check-integration check-stress guest-bins stress-bins rootfs fetch-lkl fetch-minislirp install-hooks web-assets
+.PHONY: all clean check check-unit check-integration check-stress guest-bins stress-bins rootfs fetch-lkl fetch-minislirp install-hooks web-assets indent
 
 all: $(TARGET)
 ifneq ($(wildcard .git),)
@@ -216,6 +216,29 @@ $(WEB_ASSET_SRC): $(WEB_SRCS_ALL) scripts/gen-web-assets.sh
 	./scripts/gen-web-assets.sh
 web-assets: $(WEB_ASSET_SRC)
 endif
+
+# ---- Formatting ----
+
+CLANG_FORMAT := $(shell command -v clang-format-20 2>/dev/null || \
+                        command -v clang-format 2>/dev/null)
+SHFMT        := shfmt
+BLACK        := black
+
+C_SRCS_FMT  := $(wildcard src/*.c src/*.h include/kbox/*.h \
+                tests/unit/*.c tests/unit/*.h \
+                tests/guest/*.c tests/stress/*.c)
+SH_SRCS_FMT := $(wildcard scripts/*.sh)
+PY_SRCS_FMT := $(wildcard scripts/gdb/*.py)
+
+indent:
+ifeq ($(CLANG_FORMAT),)
+	$(error clang-format not found; install clang-format or clang-format-20)
+endif
+	@$(CLANG_FORMAT) --version | grep -q 'version 20' || \
+	  { echo "error: clang-format version 20 required"; exit 1; }
+	$(CLANG_FORMAT) -i $(C_SRCS_FMT)
+	$(SHFMT) -i 4 -fn -ci -sr -bn -w $(SH_SRCS_FMT)
+	$(BLACK) -q $(PY_SRCS_FMT)
 
 clean:
 	rm -f $(OBJS) $(TARGET) $(TEST_TARGET) $(TEST_DIR)/*.o

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # common.sh -- shared helpers for kbox scripts and git hooks.
 
-set_colors() {
+set_colors()
+{
     if [ -t 1 ] && command -v tput > /dev/null 2>&1 && [ "$(tput colors 2> /dev/null)" -ge 8 ] 2> /dev/null; then
         RED='\033[0;31m'
         GREEN='\033[0;32m'

--- a/scripts/fetch-busybox.sh
+++ b/scripts/fetch-busybox.sh
@@ -12,7 +12,8 @@ BUSYBOX_VERSION="${BUSYBOX_VERSION:-1.36.1}"
 OUTDIR="deps"
 OUTFILE="${OUTDIR}/busybox"
 
-die() {
+die()
+{
     echo "error: $*" >&2
     exit 1
 }

--- a/scripts/fetch-lkl.sh
+++ b/scripts/fetch-lkl.sh
@@ -15,12 +15,12 @@ set -eu
 
 # Auto-detect architecture.
 case "${1:-$(uname -m)}" in
-x86_64 | amd64) ARCH="x86_64" ;;
-aarch64 | arm64) ARCH="aarch64" ;;
-*)
-	echo "error: unsupported architecture: ${1:-$(uname -m)}" >&2
-	exit 1
-	;;
+    x86_64 | amd64) ARCH="x86_64" ;;
+    aarch64 | arm64) ARCH="aarch64" ;;
+    *)
+        echo "error: unsupported architecture: ${1:-$(uname -m)}" >&2
+        exit 1
+        ;;
 esac
 
 LKL_DIR="${LKL_DIR:-lkl-${ARCH}}"
@@ -29,75 +29,78 @@ NIGHTLY_TAG="${KBOX_LKL_TAG:-lkl-nightly}"
 ASSET="liblkl-${ARCH}.tar.gz"
 SHA256_FILE="scripts/lkl-sha256.txt"
 
-die() {
-	echo "error: $*" >&2
-	exit 1
+die()
+{
+    echo "error: $*" >&2
+    exit 1
 }
 
 mkdir -p "$LKL_DIR"
 
 # Already present?
 if [ -f "${LKL_DIR}/liblkl.a" ]; then
-	echo "OK: ${LKL_DIR}/liblkl.a (already exists)"
-	exit 0
+    echo "OK: ${LKL_DIR}/liblkl.a (already exists)"
+    exit 0
 fi
 
 # --- Method 1: GitHub Releases (curl, no auth) ---
-try_release() {
-	if ! command -v curl >/dev/null 2>&1; then
-		return 1
-	fi
+try_release()
+{
+    if ! command -v curl > /dev/null 2>&1; then
+        return 1
+    fi
 
-	URL="https://github.com/${REPO}/releases/download/${NIGHTLY_TAG}/${ASSET}"
-	echo "Downloading ${URL}..."
-	curl -fSL -o "${LKL_DIR}/${ASSET}" "$URL" || return 1
+    URL="https://github.com/${REPO}/releases/download/${NIGHTLY_TAG}/${ASSET}"
+    echo "Downloading ${URL}..."
+    curl -fSL -o "${LKL_DIR}/${ASSET}" "$URL" || return 1
 
-	# Verify SHA256 if pinfile has an entry for this asset.
-	if [ -f "$SHA256_FILE" ]; then
-		EXPECTED=$(grep "$ASSET" "$SHA256_FILE" | awk '{print $1}')
-		if [ -n "$EXPECTED" ]; then
-			ACTUAL=$(sha256sum "${LKL_DIR}/${ASSET}" | awk '{print $1}')
-			if [ "$ACTUAL" != "$EXPECTED" ]; then
-				rm -f "${LKL_DIR}/${ASSET}"
-				die "SHA256 mismatch for ${ASSET}"
-			fi
-			echo "SHA256 verified."
-		fi
-	fi
+    # Verify SHA256 if pinfile has an entry for this asset.
+    if [ -f "$SHA256_FILE" ]; then
+        EXPECTED=$(grep "$ASSET" "$SHA256_FILE" | awk '{print $1}')
+        if [ -n "$EXPECTED" ]; then
+            ACTUAL=$(sha256sum "${LKL_DIR}/${ASSET}" | awk '{print $1}')
+            if [ "$ACTUAL" != "$EXPECTED" ]; then
+                rm -f "${LKL_DIR}/${ASSET}"
+                die "SHA256 mismatch for ${ASSET}"
+            fi
+            echo "SHA256 verified."
+        fi
+    fi
 
-	tar xzf "${LKL_DIR}/${ASSET}" -C "$LKL_DIR"
-	rm -f "${LKL_DIR}/${ASSET}"
-	return 0
+    tar xzf "${LKL_DIR}/${ASSET}" -C "$LKL_DIR"
+    rm -f "${LKL_DIR}/${ASSET}"
+    return 0
 }
 
 # --- Method 2: gh CLI ---
-try_gh() {
-	if ! command -v gh >/dev/null 2>&1; then
-		return 1
-	fi
+try_gh()
+{
+    if ! command -v gh > /dev/null 2>&1; then
+        return 1
+    fi
 
-	echo "Fetching ${ASSET} via gh CLI..."
-	TMPDIR=$(mktemp -d)
-	gh release download "$NIGHTLY_TAG" \
-		--repo "$REPO" \
-		--pattern "$ASSET" \
-		--dir "$TMPDIR" 2>/dev/null || {
-		rm -rf "$TMPDIR"
-		return 1
-	}
+    echo "Fetching ${ASSET} via gh CLI..."
+    TMPDIR=$(mktemp -d)
+    gh release download "$NIGHTLY_TAG" \
+        --repo "$REPO" \
+        --pattern "$ASSET" \
+        --dir "$TMPDIR" 2> /dev/null || {
+        rm -rf "$TMPDIR"
+        return 1
+    }
 
-	tar xzf "${TMPDIR}/${ASSET}" -C "$LKL_DIR"
-	rm -rf "$TMPDIR"
-	return 0
+    tar xzf "${TMPDIR}/${ASSET}" -C "$LKL_DIR"
+    rm -rf "$TMPDIR"
+    return 0
 }
 
 # Try methods in order.
 if try_release; then
-	:
+    :
 elif try_gh; then
-	:
+    :
 else
-	cat >&2 <<EOF
+    cat >&2 << EOF
 Cannot fetch liblkl.a automatically.
 
 Manual download:
@@ -110,11 +113,11 @@ Or build from source:
   cp tools/lkl/liblkl.a ${LKL_DIR}/
 
 EOF
-	exit 1
+    exit 1
 fi
 
 if [ -f "${LKL_DIR}/liblkl.a" ]; then
-	echo "OK: ${LKL_DIR}/liblkl.a"
+    echo "OK: ${LKL_DIR}/liblkl.a"
 else
-	die "Download succeeded but liblkl.a not found in ${LKL_DIR}/"
+    die "Download succeeded but liblkl.a not found in ${LKL_DIR}/"
 fi

--- a/scripts/fetch-minislirp.sh
+++ b/scripts/fetch-minislirp.sh
@@ -13,7 +13,10 @@ REPO="${MINISLIRP_REPO:-https://github.com/sysprog21/minislirp}"
 
 # Validate SLIRP_DIR to prevent rm -rf on unintended paths.
 case "$SLIRP_DIR" in
-    /*|""|.|..|*/..*) echo "error: SLIRP_DIR must be a relative sub-path without .." >&2; exit 1 ;;
+    /* | "" | . | .. | */..*)
+        echo "error: SLIRP_DIR must be a relative sub-path without .." >&2
+        exit 1
+        ;;
 esac
 
 if [ -f "${SLIRP_DIR}/src/libslirp.h" ]; then

--- a/scripts/gdb/kbox-gdb.py
+++ b/scripts/gdb/kbox-gdb.py
@@ -86,7 +86,9 @@ class KboxFdTable(gdb.Command):
                 mirror_tty = int(entry["mirror_tty"])
                 cloexec = int(entry["cloexec"])
                 host_str = str(host_fd) if host_fd >= 0 else "-"
-                print(f"{i:>8}  {lkl_fd:>8}  {host_str:>8}  {mirror_tty:>4}  {cloexec:>7}")
+                print(
+                    f"{i:>8}  {lkl_fd:>8}  {host_str:>8}  {mirror_tty:>4}  {cloexec:>7}"
+                )
                 count += 1
         except gdb.error:
             pass
@@ -102,7 +104,9 @@ class KboxFdTable(gdb.Command):
             mirror_tty = int(entry["mirror_tty"])
             cloexec = int(entry["cloexec"])
             host_str = str(host_fd) if host_fd >= 0 else "-"
-            print(f"{vfd:>8}  {lkl_fd:>8}  {host_str:>8}  {mirror_tty:>4}  {cloexec:>7}")
+            print(
+                f"{vfd:>8}  {lkl_fd:>8}  {host_str:>8}  {mirror_tty:>4}  {cloexec:>7}"
+            )
             count += 1
 
         print(f"\n{count} active entries")
@@ -135,7 +139,9 @@ class KboxBreakSyscall(gdb.Command):
 
         bp = gdb.Breakpoint("kbox_dispatch_syscall")
         bp.condition = f"nr == {nr}"
-        print(f"Breakpoint {bp.number} at kbox_dispatch_syscall (condition: nr == {nr})")
+        print(
+            f"Breakpoint {bp.number} at kbox_dispatch_syscall (condition: nr == {nr})"
+        )
 
 
 class KboxCtx(gdb.Command):
@@ -201,21 +207,69 @@ class KboxCtx(gdb.Command):
 
 # Host NR field names in kbox_host_nrs, used for reverse lookup.
 _HOST_NR_FIELDS = [
-    "openat", "openat2", "open", "stat", "lstat", "access",
-    "rename", "mkdir", "rmdir", "unlink", "chmod", "chown",
-    "fstat", "newfstatat", "statx", "faccessat2",
-    "getdents64", "getdents", "mkdirat", "unlinkat", "renameat2",
-    "fchmodat", "fchownat", "close",
-    "sendmsg", "socket", "connect", "bind", "listen", "accept", "accept4",
-    "exit", "exit_group", "fcntl", "dup", "dup2", "dup3",
-    "read", "write", "pread64", "lseek",
-    "chdir", "fchdir", "getcwd",
-    "getuid", "geteuid", "getresuid",
-    "getgid", "getegid", "getresgid",
-    "setuid", "setreuid", "setresuid",
-    "setgid", "setregid", "setresgid",
-    "getgroups", "setgroups", "setfsgid",
-    "mount", "umount2", "execve", "execveat",
+    "openat",
+    "openat2",
+    "open",
+    "stat",
+    "lstat",
+    "access",
+    "rename",
+    "mkdir",
+    "rmdir",
+    "unlink",
+    "chmod",
+    "chown",
+    "fstat",
+    "newfstatat",
+    "statx",
+    "faccessat2",
+    "getdents64",
+    "getdents",
+    "mkdirat",
+    "unlinkat",
+    "renameat2",
+    "fchmodat",
+    "fchownat",
+    "close",
+    "sendmsg",
+    "socket",
+    "connect",
+    "bind",
+    "listen",
+    "accept",
+    "accept4",
+    "exit",
+    "exit_group",
+    "fcntl",
+    "dup",
+    "dup2",
+    "dup3",
+    "read",
+    "write",
+    "pread64",
+    "lseek",
+    "chdir",
+    "fchdir",
+    "getcwd",
+    "getuid",
+    "geteuid",
+    "getresuid",
+    "getgid",
+    "getegid",
+    "getresgid",
+    "setuid",
+    "setreuid",
+    "setresuid",
+    "setgid",
+    "setregid",
+    "setresgid",
+    "getgroups",
+    "setgroups",
+    "setfsgid",
+    "mount",
+    "umount2",
+    "execve",
+    "execveat",
 ]
 
 
@@ -281,9 +335,7 @@ class KboxSyscallTrace(gdb.Command):
             return
 
         bp_dispatch.commands = (
-            "silent\n"
-            "python KboxSyscallTrace._on_dispatch()\n"
-            "continue"
+            "silent\n" "python KboxSyscallTrace._on_dispatch()\n" "continue"
         )
 
         # Breakpoint on lkl_syscall -- the single entry point into the
@@ -296,9 +348,7 @@ class KboxSyscallTrace(gdb.Command):
             return
 
         bp_lkl.commands = (
-            "silent\n"
-            "python KboxSyscallTrace._on_lkl_entry()\n"
-            "continue"
+            "silent\n" "python KboxSyscallTrace._on_lkl_entry()\n" "continue"
         )
 
         # Finish breakpoint on lkl_syscall to capture the return value.
@@ -312,9 +362,7 @@ class KboxSyscallTrace(gdb.Command):
 
         if bp_lkl6:
             bp_lkl6.commands = (
-                "silent\n"
-                "python KboxSyscallTrace._on_lkl6_entry()\n"
-                "continue"
+                "silent\n" "python KboxSyscallTrace._on_lkl6_entry()\n" "continue"
             )
 
         print(f"Syscall trace active:")
@@ -388,7 +436,7 @@ class KboxSyscallTrace(gdb.Command):
         except gdb.error:
             fd_base = 32768
 
-        a0 = int(args[0]) & 0xffffffffffffffff
+        a0 = int(args[0]) & 0xFFFFFFFFFFFFFFFF
         # Signed interpretation for AT_FDCWD check.
         a0_signed = int(args[0])
         if a0_signed != -100 and a0 >= fd_base and a0 < fd_base + 4096:
@@ -480,9 +528,7 @@ class KboxVfsPath(gdb.Command):
     """
 
     def __init__(self):
-        super().__init__(
-            "kbox-vfs-path", gdb.COMMAND_DATA, gdb.COMPLETE_FILENAME
-        )
+        super().__init__("kbox-vfs-path", gdb.COMMAND_DATA, gdb.COMPLETE_FILENAME)
 
     @staticmethod
     def _normalize_join(base, path):
@@ -544,7 +590,7 @@ class KboxVfsPath(gdb.Command):
         """Check if path equals prefix or starts with prefix + '/'."""
         if not path.startswith(prefix):
             return False
-        rest = path[len(prefix):]
+        rest = path[len(prefix) :]
         return rest == "" or rest.startswith("/")
 
     def invoke(self, arg, from_tty):
@@ -639,7 +685,7 @@ class KboxVfsPath(gdb.Command):
         # Escape check.
         if self._is_prefix_dir(resolved, host_root) or resolved == host_root:
             # Strip host_root prefix to get guest-relative path.
-            tail = resolved[len(host_root):]
+            tail = resolved[len(host_root) :]
             if tail == "":
                 guest_resolved = "/"
             elif tail.startswith("/"):
@@ -675,9 +721,7 @@ class KboxTaskWalk(gdb.Command):
     """
 
     def __init__(self):
-        super().__init__(
-            "kbox-task-walk", gdb.COMMAND_DATA, gdb.COMPLETE_EXPRESSION
-        )
+        super().__init__("kbox-task-walk", gdb.COMMAND_DATA, gdb.COMPLETE_EXPRESSION)
 
     @staticmethod
     def _container_of(list_ptr, struct_type, member_name):
@@ -692,9 +736,7 @@ class KboxTaskWalk(gdb.Command):
         member_offset = 0
         try:
             # Use GDB to compute the offset.
-            offset_expr = (
-                f"(unsigned long)&((({struct_type} *)0)->{member_name})"
-            )
+            offset_expr = f"(unsigned long)&((({struct_type} *)0)->{member_name})"
             member_offset = int(gdb.parse_and_eval(offset_expr))
         except gdb.error:
             # Manual fallback: iterate fields.
@@ -818,9 +860,7 @@ class KboxTaskWalk(gdb.Command):
                     if pid == 1:
                         tracee_str = f"<-> {child_pid} (tracee)"
 
-                print(
-                    f"{pid:>6}  {state_str:>16}  {comm:>16}  {tracee_str:>10}"
-                )
+                print(f"{pid:>6}  {state_str:>16}  {comm:>16}  {tracee_str:>10}")
                 count += 1
 
                 # Follow tasks.next to the next task.
@@ -833,9 +873,7 @@ class KboxTaskWalk(gdb.Command):
                     break
 
                 # container_of(next_list, struct task_struct, tasks)
-                current = self._container_of(
-                    next_list, "struct task_struct", "tasks"
-                )
+                current = self._container_of(next_list, "struct task_struct", "tasks")
                 if current is None:
                     print("[error] container_of failed during traversal")
                     break
@@ -867,9 +905,7 @@ class KboxMemCheck(gdb.Command):
     MAX_ORDER = 11
 
     def __init__(self):
-        super().__init__(
-            "kbox-mem-check", gdb.COMMAND_DATA, gdb.COMPLETE_NONE
-        )
+        super().__init__("kbox-mem-check", gdb.COMMAND_DATA, gdb.COMPLETE_NONE)
 
     @staticmethod
     def _read_list_len(head_addr, max_count=4096):
@@ -973,16 +1009,15 @@ class KboxMemCheck(gdb.Command):
                     pages = nr_free * (1 << order)
                     zone_free += pages
                     block_kb = (1 << order) * 4  # Assume 4KB pages.
-                    print(
-                        f"  {order:>6}  {nr_free:>12}  "
-                        f"{block_kb:>8} KB"
-                    )
+                    print(f"  {order:>6}  {nr_free:>12}  " f"{block_kb:>8} KB")
 
                 total_free_pages += zone_free
                 print(f"  zone total: {zone_free} pages ({zone_free * 4} KB)")
 
-            print(f"\n  buddy total free: {total_free_pages} pages "
-                  f"({total_free_pages * 4} KB)")
+            print(
+                f"\n  buddy total free: {total_free_pages} pages "
+                f"({total_free_pages * 4} KB)"
+            )
 
         # ---------------------------------------------------------- #
         # Slab allocator -- slab_caches list                          #
@@ -1026,18 +1061,14 @@ class KboxMemCheck(gdb.Command):
                     max_caches = 512  # Safety limit.
 
                     try:
-                        list_head_type = gdb.lookup_type(
-                            "struct list_head"
-                        ).pointer()
+                        list_head_type = gdb.lookup_type("struct list_head").pointer()
                         ptr = int(slab_caches["next"])
 
                         while ptr != head_addr and cache_count < max_caches:
                             # container_of: ptr points to
                             # kmem_cache.list, subtract offset.
                             cache_addr = ptr - list_offset
-                            cache_ptr = gdb.Value(cache_addr).cast(
-                                cache_type.pointer()
-                            )
+                            cache_ptr = gdb.Value(cache_addr).cast(cache_type.pointer())
                             cache = cache_ptr.dereference()
 
                             # Read cache fields.
@@ -1061,15 +1092,10 @@ class KboxMemCheck(gdb.Command):
                             except gdb.error:
                                 size = -1
 
-                            obj_str = (
-                                f"{obj_size}" if obj_size >= 0 else "?"
-                            )
+                            obj_str = f"{obj_size}" if obj_size >= 0 else "?"
                             size_str = f"{size}" if size >= 0 else "?"
 
-                            print(
-                                f"  {cname:>24}  {obj_str:>10}  "
-                                f"{size_str:>10}"
-                            )
+                            print(f"  {cname:>24}  {obj_str:>10}  " f"{size_str:>10}")
                             cache_count += 1
 
                             # Follow list.next.
@@ -1120,8 +1146,7 @@ class KboxMemCheck(gdb.Command):
             # Without totalram_pages, report what we can.
             if total_free_pages > 0:
                 print(
-                    f"  free pages: {total_free_pages} "
-                    f"({total_free_pages * 4} KB)"
+                    f"  free pages: {total_free_pages} " f"({total_free_pages * 4} KB)"
                 )
                 print(f"  totalram_pages not available for pressure calc")
             else:
@@ -1155,17 +1180,17 @@ class KboxLklLoad(gdb.Command):
     """
 
     def __init__(self):
-        super().__init__(
-            "kbox-lkl-load", gdb.COMMAND_DATA, gdb.COMPLETE_FILENAME
-        )
+        super().__init__("kbox-lkl-load", gdb.COMMAND_DATA, gdb.COMPLETE_FILENAME)
 
     def invoke(self, arg, from_tty):
         import os
         import sys
         import types
 
-        lkl_dir = arg.strip() if arg.strip() else os.environ.get(
-            "LKL_DIR", os.path.expanduser("~/TEMP/lkl")
+        lkl_dir = (
+            arg.strip()
+            if arg.strip()
+            else os.environ.get("LKL_DIR", os.path.expanduser("~/TEMP/lkl"))
         )
 
         gdb_scripts = os.path.join(lkl_dir, "scripts", "gdb")
@@ -1186,9 +1211,11 @@ class KboxLklLoad(gdb.Command):
         patched = []
         for line in lines:
             stripped = line.strip()
-            if ("gdb.parse_and_eval" in line
-                    and not stripped.startswith("#")
-                    and not stripped.startswith("if 0")):
+            if (
+                "gdb.parse_and_eval" in line
+                and not stripped.startswith("#")
+                and not stripped.startswith("if 0")
+            ):
                 indent = len(line) - len(line.lstrip())
                 sp = " " * indent
                 varname = stripped.split("=")[0].strip()

--- a/scripts/gdb/test_vfs_path.py
+++ b/scripts/gdb/test_vfs_path.py
@@ -15,6 +15,7 @@ import os
 
 # Stub gdb module so kbox-gdb.py can be imported without GDB.
 import types
+
 gdb_stub = types.ModuleType("gdb")
 gdb_stub.COMMAND_DATA = 0
 gdb_stub.COMMAND_BREAKPOINTS = 1
@@ -23,13 +24,19 @@ gdb_stub.COMPLETE_NONE = 0
 gdb_stub.COMPLETE_FILENAME = 0
 gdb_stub.TYPE_CODE_PTR = 0
 
+
 class StubCommand:
     def __init__(self, *args, **kwargs):
         pass
+
+
 gdb_stub.Command = StubCommand
+
 
 class StubValue:
     pass
+
+
 gdb_stub.Value = StubValue
 gdb_stub.error = Exception
 gdb_stub.parse_and_eval = lambda x: None
@@ -42,6 +49,7 @@ sys.path.insert(0, script_dir)
 
 # Use importlib to load the module despite the hyphen in the filename.
 import importlib.util
+
 spec = importlib.util.spec_from_file_location(
     "kbox_gdb", os.path.join(script_dir, "kbox-gdb.py")
 )
@@ -56,6 +64,7 @@ is_prefix_dir = kbox_gdb.KboxVfsPath._is_prefix_dir
 
 passed = 0
 failed = 0
+
 
 def check(name, got, expected):
     global passed, failed
@@ -99,9 +108,7 @@ check("trailing_slash", normalize_join("/base", "/path/"), "/path")
 check("double_slash", normalize_join("/base", "/path//to///file"), "/path/to/file")
 
 # Complex mixed.
-check("complex_mixed",
-      normalize_join("/base", "/a/b/../c/./d/../e"),
-      "/a/c/e")
+check("complex_mixed", normalize_join("/base", "/a/b/../c/./d/../e"), "/a/c/e")
 
 # The escape cases from the C tests:
 
@@ -163,12 +170,14 @@ check("prefix_no", is_prefix_dir("/processor", "/proc"), False)
 check("prefix_root", is_prefix_dir("/", "/"), True)
 
 # Host-mode escape boundary: /var/lib/container_escape vs /var/lib/container
-check("prefix_escape",
-      is_prefix_dir("/var/lib/container_escape", "/var/lib/container"),
-      False)
-check("prefix_valid",
-      is_prefix_dir("/var/lib/container/file", "/var/lib/container"),
-      True)
+check(
+    "prefix_escape",
+    is_prefix_dir("/var/lib/container_escape", "/var/lib/container"),
+    False,
+)
+check(
+    "prefix_valid", is_prefix_dir("/var/lib/container/file", "/var/lib/container"), True
+)
 
 # ---- is_loader_runtime tests ----
 

--- a/scripts/mkrootfs.sh
+++ b/scripts/mkrootfs.sh
@@ -25,8 +25,8 @@ STAGING=""
 ALPINE_VERSION="3.21"
 if [ -z "${ALPINE_ARCH:-}" ]; then
     case "$(uname -m)" in
-        aarch64|arm64) ALPINE_ARCH="aarch64" ;;
-        x86_64|amd64)  ALPINE_ARCH="x86_64" ;;
+        aarch64 | arm64) ALPINE_ARCH="aarch64" ;;
+        x86_64 | amd64) ALPINE_ARCH="x86_64" ;;
         *) die "Unsupported host architecture: $(uname -m). Set ALPINE_ARCH explicitly." ;;
     esac
 fi
@@ -34,12 +34,14 @@ ALPINE_TARBALL="alpine-minirootfs-${ALPINE_VERSION}.0-${ALPINE_ARCH}.tar.gz"
 ALPINE_URL="https://dl-cdn.alpinelinux.org/alpine/v${ALPINE_VERSION}/releases/${ALPINE_ARCH}/${ALPINE_TARBALL}"
 ALPINE_SHA256_FILE="scripts/alpine-sha256.txt"
 
-die() {
+die()
+{
     echo "error: $*" >&2
     exit 1
 }
 
-cleanup() {
+cleanup()
+{
     if [ -n "$STAGING" ] && [ -d "$STAGING" ]; then
         rm -rf "$STAGING"
     fi

--- a/scripts/run-stress.sh
+++ b/scripts/run-stress.sh
@@ -39,7 +39,8 @@ else
     NC=''
 fi
 
-die() {
+die()
+{
     echo "error: $*" >&2
     exit 1
 }
@@ -56,7 +57,8 @@ else
     TIMEOUT_CMD=""
 fi
 
-run_stress_test() {
+run_stress_test()
+{
     name="$1"
     guest_path="$2"
     shift 2

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -35,7 +35,8 @@ else
     NC=''
 fi
 
-die() {
+die()
+{
     echo "error: $*" >&2
     exit 1
 }
@@ -43,7 +44,8 @@ die() {
 [ -x "$KBOX" ] || die "kbox binary not found at ${KBOX}"
 [ -f "$ROOTFS" ] || die "rootfs image not found at ${ROOTFS}"
 
-expect_success() {
+expect_success()
+{
     name="$1"
     shift
     printf "  %-40s " "$name"
@@ -59,7 +61,8 @@ expect_success() {
     rm -f "$OUTPUT"
 }
 
-expect_output() {
+expect_output()
+{
     name="$1"
     expected="$2"
     shift 2

--- a/src/seccomp-dispatch.c
+++ b/src/seccomp-dispatch.c
@@ -731,8 +731,7 @@ static struct kbox_dispatch forward_write(
 
 /* forward_sendfile. */
 
-/*
- * Emulate sendfile(out_fd, in_fd, *offset, count).
+/* Emulate sendfile(out_fd, in_fd, *offset, count).
  *
  * If both FDs are host-visible (shadow memfds, stdio, or other host FDs
  * not in the virtual table), let the host kernel handle it via CONTINUE.
@@ -753,8 +752,7 @@ static struct kbox_dispatch forward_sendfile(
     long in_lkl = kbox_fd_table_get_lkl(ctx->fd_table, in_fd);
     long out_lkl = kbox_fd_table_get_lkl(ctx->fd_table, out_fd);
 
-    /*
-     * Resolve shadow FDs: if in_fd is a host FD injected via ADDFD (shadow
+    /* Resolve shadow FDs: if in_fd is a host FD injected via ADDFD (shadow
      * memfd), find_by_host_fd locates the virtual entry that holds the LKL
      * FD for the same file.
      */
@@ -769,15 +767,13 @@ static struct kbox_dispatch forward_sendfile(
             out_lkl = kbox_fd_table_get_lkl(ctx->fd_table, vfd);
     }
 
-    /*
-     * Both FDs are host-visible (shadow memfds, stdio, pipes, etc.) and
+    /* Both FDs are host-visible (shadow memfds, stdio, pipes, etc.) and
      * neither has LKL backing.  The host kernel handles sendfile.
      */
     if (in_lkl < 0 && out_lkl < 0)
         return kbox_dispatch_continue();
 
-    /*
-     * At least one FD is virtual/LKL-backed: emulate via read + write.
+    /* At least one FD is virtual/LKL-backed: emulate via read + write.
      * Source must have an LKL FD for emulation.
      */
     if (in_lkl < 0)
@@ -841,8 +837,7 @@ static struct kbox_dispatch forward_sendfile(
                 break;
             }
         } else {
-            /*
-             * Destination is a host FD (e.g. stdout).  The supervisor
+            /* Destination is a host FD (e.g. stdout).  The supervisor
              * shares the FD table with the tracee (from fork), so write()
              * goes to the same file description.
              */
@@ -1138,8 +1133,7 @@ static struct kbox_dispatch forward_dup2(const struct kbox_seccomp_notif *notif,
                 }
             }
         }
-        /*
-         * oldfd is a host FD.  If newfd has a stale LKL redirect (from
+        /* oldfd is a host FD.  If newfd has a stale LKL redirect (from
          * a previous dup2), clean it up before the host kernel overwrites
          * the FD.  Without this, the shell's dup2(saved_stdout, 1) leaves
          * a stale low_fds entry that traps all subsequent writes to FD 1
@@ -1175,8 +1169,7 @@ static struct kbox_dispatch forward_dup2(const struct kbox_seccomp_notif *notif,
     if (oldfd == newfd)
         return kbox_dispatch_value((int64_t) newfd);
 
-    /*
-     * Dup first, then close the old mapping.  This preserves the old newfd
+    /* Dup first, then close the old mapping.  This preserves the old newfd
      * if the dup fails (e.g. EMFILE), matching dup2 atomicity semantics.
      */
     long ret = kbox_lkl_dup(ctx->sysnrs, lkl_old);
@@ -2631,8 +2624,7 @@ static struct kbox_dispatch forward_sendto(
     return kbox_dispatch_from_lkl(ret);
 }
 
-/*
- * forward_recvfrom: for shadow sockets, receive data + source address from
+/* forward_recvfrom: for shadow sockets, receive data + source address from
  * the LKL socket and write them back to the tracee.
  *
  * recvfrom(fd, buf, len, flags, src_addr, addrlen)
@@ -2702,8 +2694,7 @@ static struct kbox_dispatch forward_recvfrom(
     return kbox_dispatch_value(ret);
 }
 
-/*
- * forward_recvmsg: intercept for shadow sockets so that msg_name (source
+/* forward_recvmsg: intercept for shadow sockets so that msg_name (source
  * address) is populated from the LKL socket, not the AF_UNIX socketpair.
  *
  * recvmsg(fd, msg, flags)
@@ -2867,8 +2858,7 @@ static struct kbox_dispatch forward_gettimeofday(
     uint64_t remote_tv = notif->data.args[0];
     uint64_t remote_tz = notif->data.args[1];
 
-    /*
-     * Use clock_gettime(CLOCK_REALTIME) as the underlying source, which
+    /* Use clock_gettime(CLOCK_REALTIME) as the underlying source, which
      * works on both x86_64 and aarch64.
      */
     if (remote_tv != 0) {
@@ -2968,8 +2958,7 @@ static struct kbox_dispatch forward_pipe2(
     if (remote_pipefd == 0)
         return kbox_dispatch_errno(EFAULT);
 
-    /*
-     * Create a real host pipe and inject both ends into the tracee via
+    /* Create a real host pipe and inject both ends into the tracee via
      * SECCOMP_IOCTL_NOTIF_ADDFD.  This makes pipes fully native:
      *
      *   - dup2/close/read/write on pipe FDs -> CONTINUE (host kernel)
@@ -3063,8 +3052,7 @@ static struct kbox_dispatch forward_getrandom(
     if (buflen == 0)
         return kbox_dispatch_value(0);
 
-    /*
-     * Read from /dev/urandom via LKL.  Fall back to host if LKL does not
+    /* Read from /dev/urandom via LKL.  Fall back to host if LKL does not
      * have the device available.
      */
     size_t max_chunk = 256;
@@ -3095,8 +3083,7 @@ static struct kbox_dispatch forward_getrandom(
 
 /* forward_syslog (klogctl). */
 
-/*
- * syslog(type, buf, len): forward to LKL so dmesg shows the LKL kernel's
+/* syslog(type, buf, len): forward to LKL so dmesg shows the LKL kernel's
  * ring buffer, not the host's.
  *
  * Types that read into buf (2=READ, 3=READ_ALL, 4=READ_CLEAR): call LKL
@@ -3133,8 +3120,7 @@ static struct kbox_dispatch forward_syslog(
     if (remote_buf == 0)
         return kbox_dispatch_errno(EFAULT);
 
-    /*
-     * Static buffer; safe because the supervisor is single-threaded.
+    /* Static buffer; safe because the supervisor is single-threaded.
      * Clamp to the actual LKL ring buffer size so READ_CLEAR never
      * discards data beyond what we can copy out.  The ring buffer size is
      * fixed at boot, so cache it after the first query.  Hard-cap at 1MB
@@ -3187,8 +3173,7 @@ static struct kbox_dispatch forward_prctl(
 {
     long option = to_c_long_arg(notif->data.args[0]);
 
-    /*
-     * Block PR_SET_DUMPABLE(0): clearing dumpability makes process_vm_readv
+    /* Block PR_SET_DUMPABLE(0): clearing dumpability makes process_vm_readv
      * fail, which would bypass clone3 namespace-flag sanitization (the
      * supervisor can't read clone_args.flags from a non-dumpable process).
      * Return success without actually clearing; the tracee thinks it
@@ -3200,8 +3185,7 @@ static struct kbox_dispatch forward_prctl(
     if (option == PR_GET_DUMPABLE)
         return kbox_dispatch_value(1);
 
-    /*
-     * Only forward PR_SET_NAME and PR_GET_NAME to LKL.  Everything else
+    /* Only forward PR_SET_NAME and PR_GET_NAME to LKL.  Everything else
      * passes through to the host kernel.
      *
      * PR_SET_NAME/PR_GET_NAME use a 16-byte name buffer.  The tracee
@@ -3701,8 +3685,7 @@ static struct kbox_dispatch forward_utimensat(
     pid_t pid = notif->pid;
     long dirfd_raw = to_dirfd_arg(notif->data.args[0]);
 
-    /*
-     * pathname can be NULL for utimensat (operates on dirfd itself).  In
+    /* pathname can be NULL for utimensat (operates on dirfd itself).  In
      * that case args[1] == 0.
      */
     char pathbuf[KBOX_MAX_PATH];
@@ -3785,8 +3768,7 @@ static struct kbox_dispatch forward_ioctl(
     long lkl_fd = kbox_fd_table_get_lkl(ctx->fd_table, fd);
 
     if (lkl_fd < 0) {
-        /*
-         * Host FD (stdin/stdout/stderr or pipe).  Most ioctls pass through
+        /* Host FD (stdin/stdout/stderr or pipe).  Most ioctls pass through
          * to the host kernel.  However, job-control ioctls (TIOCSPGRP/
          * TIOCGPGRP) fail with EPERM under seccomp-unotify because the
          * supervised child is not the session leader.  Return ENOTTY so
@@ -3799,8 +3781,7 @@ static struct kbox_dispatch forward_ioctl(
 
     (void) lkl_fd;
 
-    /*
-     * For virtual FDs backed by LKL, terminal ioctls return ENOTTY since
+    /* For virtual FDs backed by LKL, terminal ioctls return ENOTTY since
      * LKL file-backed FDs are not terminals.  Non-terminal ioctls also
      * return ENOTTY, matching regular-file semantics.
      */
@@ -3809,16 +3790,14 @@ static struct kbox_dispatch forward_ioctl(
 
 /* forward_mmap. */
 
-/*
- * mmap dispatch: the only case we intercept is a virtual FD with no host
+/* mmap dispatch: the only case we intercept is a virtual FD with no host
  * shadow.  Everything else (MAP_ANONYMOUS, shadow FDs, host FDs) passes
  * through to the host kernel via CONTINUE.
  */
 static struct kbox_dispatch forward_mmap(const struct kbox_seccomp_notif *notif,
                                          struct kbox_supervisor_ctx *ctx)
 {
-    /*
-     * mmap fd is a 32-bit int.  In seccomp_data.args[] it is zero-extended
+    /* mmap fd is a 32-bit int.  In seccomp_data.args[] it is zero-extended
      * to uint64_t, so -1 appears as 0xffffffff.  Use to_dirfd_arg to
      * properly sign-extend from 32 bits.
      */
@@ -3828,8 +3807,7 @@ static struct kbox_dispatch forward_mmap(const struct kbox_seccomp_notif *notif,
     if (fd == -1)
         return kbox_dispatch_continue();
 
-    /*
-     * If fd is a virtual FD (tracked in our table) and has no host shadow,
+    /* If fd is a virtual FD (tracked in our table) and has no host shadow,
      * the host kernel cannot resolve it.  Return ENODEV.  This covers both
      * high-range (>= KBOX_FD_BASE) and low-range (dup2 redirects) virtual
      * FDs.
@@ -3851,8 +3829,7 @@ static struct kbox_dispatch forward_mmap(const struct kbox_seccomp_notif *notif,
 /* In host+neither mode, CONTINUE to host kernel.                     */
 /* In image mode, forward to LKL.                                     */
 
-/*
- * Macro to reduce repetition in the identity dispatch.  For a given identity
+/* Macro to reduce repetition in the identity dispatch.  For a given identity
  * syscall, check the mode and route accordingly.
  *
  * GET_ID: host+root -> override(0), host+!root+override ->
@@ -3900,8 +3877,7 @@ static struct kbox_dispatch forward_mmap(const struct kbox_seccomp_notif *notif,
  */
 #define KBOX_AT_EMPTY_PATH 0x1000
 
-/*
- * Handle execve/execveat from inside the image.
+/* Handle execve/execveat from inside the image.
  *
  * For fexecve (execveat with AT_EMPTY_PATH on a host memfd): CONTINUE,
  * the host kernel handles it directly.  This is the initial exec path
@@ -3927,8 +3903,7 @@ static struct kbox_dispatch forward_execve(
 {
     pid_t pid = notif->pid;
 
-    /*
-     * Detect fexecve: execveat(fd, "", argv, envp, AT_EMPTY_PATH).  This
+    /* Detect fexecve: execveat(fd, "", argv, envp, AT_EMPTY_PATH).  This
      * is the initial exec from image.c on the host memfd.  Let the kernel
      * handle it directly.
      */
@@ -3970,8 +3945,7 @@ static struct kbox_dispatch forward_execve(
     if (exec_memfd < 0)
         return kbox_dispatch_errno(-exec_memfd);
 
-    /*
-     * Check for PT_INTERP (dynamic binary).  Read the first 4 KB; enough
+    /* Check for PT_INTERP (dynamic binary).  Read the first 4 KB; enough
      * for any reasonable ELF header plus the full program header table.
      */
     {
@@ -4010,8 +3984,7 @@ static struct kbox_dispatch forward_execve(
                     return kbox_dispatch_errno(-interp_memfd);
                 }
 
-                /*
-                 * Inject the interpreter memfd first so we know its FD
+                /* Inject the interpreter memfd first so we know its FD
                  * number in the tracee for the PT_INTERP patch.  O_CLOEXEC
                  * is safe: the kernel resolves /proc/self/fd/N via
                  * open_exec() before begin_new_exec() closes CLOEXEC
@@ -4060,8 +4033,7 @@ static struct kbox_dispatch forward_execve(
         }
     }
 
-    /*
-     * Inject the exec memfd into the tracee.  O_CLOEXEC keeps the tracee's
+    /* Inject the exec memfd into the tracee.  O_CLOEXEC keeps the tracee's
      * FD table clean after exec succeeds.
      */
     int tracee_exec_fd =
@@ -4071,8 +4043,7 @@ static struct kbox_dispatch forward_execve(
     if (tracee_exec_fd < 0)
         return kbox_dispatch_errno(-tracee_exec_fd);
 
-    /*
-     * Overwrite the pathname in the tracee's memory with /proc/self/fd/<N>.
+    /* Overwrite the pathname in the tracee's memory with /proc/self/fd/<N>.
      * The kernel has not yet copied the pathname (getname happens after
      * the seccomp check), so when we CONTINUE, it reads our rewritten
      * path.
@@ -4587,8 +4558,7 @@ struct kbox_dispatch kbox_dispatch_syscall(struct kbox_supervisor_ctx *ctx,
         return kbox_dispatch_continue(); /* alarm (not on aarch64) */
 
     /* Signal delivery (dispatch: PID validation). */
-    /*
-     * kill/tgkill/tkill must go through dispatch (not BPF deny) because ash
+    /* kill/tgkill/tkill must go through dispatch (not BPF deny) because ash
      * needs them for job control. We validate the target PID belongs to the
      * guest process tree.  PID is in register args (no TOCTOU).
      */

--- a/src/seccomp-notify.c
+++ b/src/seccomp-notify.c
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: MIT */
-/*
- * seccomp-notify.c - ioctl wrappers for seccomp user notifications.
+/* seccomp-notify.c - ioctl wrappers for seccomp user notifications.
  *
  * Thin wrappers around the three seccomp-unotify ioctls:
  *   SECCOMP_IOCTL_NOTIF_RECV   - receive a notification

--- a/src/seccomp-supervisor.c
+++ b/src/seccomp-supervisor.c
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: MIT */
-/*
- * seccomp-supervisor.c - Fork, install seccomp, exec, supervise.
+/* seccomp-supervisor.c - Fork, install seccomp, exec, supervise.
  *
  * The supervisor creates a socketpair, forks a child process, installs
  * a seccomp-unotify BPF filter in the child, sends the listener FD
@@ -30,15 +29,13 @@
 #include "web.h"
 #endif
 
-/*
- * Notification types (kbox_seccomp_notif etc.) are provided by
+/* Notification types (kbox_seccomp_notif etc.) are provided by
  * seccomp-defs.h via seccomp.h.
  */
 
 /* SCM_RIGHTS helpers. */
 
-/*
- * Create a UNIX socketpair.
+/* Create a UNIX socketpair.
  * On success fds[0] and fds[1] are filled; returns 0.
  * On failure returns -1 with a message on stderr.
  */
@@ -51,8 +48,7 @@ static int socketpair_create(int fds[2])
     return 0;
 }
 
-/*
- * Send a single file descriptor over a UNIX socket using SCM_RIGHTS.
+/* Send a single file descriptor over a UNIX socket using SCM_RIGHTS.
  */
 static int send_fd(int sock, int fd)
 {
@@ -62,8 +58,7 @@ static int send_fd(int sock, int fd)
         .iov_len = 1,
     };
 
-    /*
-     * Ancillary data buffer.  CMSG_SPACE gives the padded size
+    /* Ancillary data buffer.  CMSG_SPACE gives the padded size
      * needed to carry one int.
      */
     union {
@@ -101,8 +96,7 @@ static int send_fd(int sock, int fd)
     return 0;
 }
 
-/*
- * Receive a single file descriptor from a UNIX socket via SCM_RIGHTS.
+/* Receive a single file descriptor from a UNIX socket via SCM_RIGHTS.
  * Returns the received FD on success, -1 on error.
  */
 static int recv_fd(int sock)
@@ -181,8 +175,7 @@ static void build_response(struct kbox_seccomp_notif_resp *resp,
     case KBOX_DISPATCH_RETURN:
         resp->flags = 0;
         resp->val = d->val;
-        /*
-         * seccomp_notif_resp.error is a negative errno value.
+        /* seccomp_notif_resp.error is a negative errno value.
          * The kernel negates it to produce the tracee's errno:
          *   error = -ENOENT (-2)  =>  tracee errno = 2 (ENOENT)
          * kbox_dispatch_errno stores positive values, so negate here.
@@ -194,8 +187,7 @@ static void build_response(struct kbox_seccomp_notif_resp *resp,
 
 /* Child wait helper. */
 
-/*
- * Check child status via non-blocking waitpid.
+/* Check child status via non-blocking waitpid.
  * Returns:
  *   1  if child exited; *exit_code is filled with the exit status.
  *   0  if child is still running.
@@ -225,8 +217,7 @@ static int check_child(pid_t pid, int *exit_code)
 
 /* Supervisor loop. */
 
-/*
- * Sit in a poll loop:
+/* Sit in a poll loop:
  *   1. Non-blocking waitpid to see if child exited.
  *   2. poll(listener_fd, POLLIN, 100ms).
  *   3. On POLLHUP/POLLERR, recheck child.
@@ -336,8 +327,7 @@ static int supervise_loop(struct kbox_supervisor_ctx *ctx)
 
         if (ret < 0) {
             int e = -ret;
-            /*
-             * ENOENT: tracee died between recv and send.
+            /* ENOENT: tracee died between recv and send.
              * EBADF: notification ID invalidated (thread exit
              *        in a multi-threaded guest).
              * Both are harmless; loop around, waitpid picks
@@ -402,8 +392,7 @@ int kbox_run_supervisor(const struct kbox_sysnrs *sysnrs,
         /* Child process. */
         close(sp[0]);
 
-        /*
-         * Raise RLIMIT_NOFILE so the host kernel allows FD numbers
+        /* Raise RLIMIT_NOFILE so the host kernel allows FD numbers
          * above the default limit (typically 1024).  The guest shell
          * (busybox ash) saves/restores FDs via fcntl(F_DUPFD, minfd)
          * where minfd can be above 4096 when virtual FDs are in use.
@@ -416,8 +405,7 @@ int kbox_run_supervisor(const struct kbox_sysnrs *sysnrs,
             setrlimit(RLIMIT_NOFILE, &rl);
         }
 
-        /*
-         * Prevent RT scheduling starvation: cap RLIMIT_RTPRIO to 0
+        /* Prevent RT scheduling starvation: cap RLIMIT_RTPRIO to 0
          * so sched_setscheduler(SCHED_FIFO/RR) fails with EPERM.
          * This makes sched_* CONTINUE entries safe.
          */
@@ -433,8 +421,7 @@ int kbox_run_supervisor(const struct kbox_sysnrs *sysnrs,
             _exit(127);
         }
 
-        /*
-         * Drop all ambient capabilities and clear the bounding set.
+        /* Drop all ambient capabilities and clear the bounding set.
          * This limits what the child can do even if it somehow
          * gains privileges.  Errors are ignored: a given cap number
          * may not exist on this kernel.
@@ -460,8 +447,7 @@ int kbox_run_supervisor(const struct kbox_sysnrs *sysnrs,
         close(sp[1]);
         close(listener_fd);
 
-        /*
-         * 3e. Build argv and exec.
+        /* 3e. Build argv and exec.
          *
          * argv[0] = command, then args[0..nargs], then NULL.
          *

--- a/src/shadow-fd.c
+++ b/src/shadow-fd.c
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: MIT */
-/*
- * shadow-fd.c - Create host-visible memfd shadows of LKL files.
+/* shadow-fd.c - Create host-visible memfd shadows of LKL files.
  *
  * When the guest opens a regular file O_RDONLY, we create a memfd
  * containing the file's contents and inject it into the tracee.
@@ -23,8 +22,7 @@
 
 int kbox_shadow_create(const struct kbox_sysnrs *s, long lkl_fd)
 {
-    /*
-     * Use kbox_lkl_stat (generic-arch layout) instead of struct stat
+    /* Use kbox_lkl_stat (generic-arch layout) instead of struct stat
      * (x86_64 layout).  LKL always fills the buffer in generic-arch
      * format regardless of the host architecture.
      */
@@ -55,8 +53,7 @@ int kbox_shadow_create(const struct kbox_sysnrs *s, long lkl_fd)
         return -e;
     }
 
-    /*
-     * Read from LKL in chunks via pread64 (position-independent)
+    /* Read from LKL in chunks via pread64 (position-independent)
      * and write to the memfd.
      */
     long off = 0;

--- a/src/syscall-nr.c
+++ b/src/syscall-nr.c
@@ -523,8 +523,7 @@ const struct kbox_host_nrs HOST_NRS_AARCH64 = {
 };
 
 #ifndef KBOX_UNIT_TEST
-/*
- * LKL ARCH=lkl always uses the asm-generic ABI.  No runtime probing
+/* LKL ARCH=lkl always uses the asm-generic ABI.  No runtime probing
  * needed; the generic syscall table is the only one that applies.
  *
  * The old mkdir-based runtime probe is retained under KBOX_DEBUG_ABI_PROBE
@@ -580,8 +579,7 @@ const struct kbox_sysnrs *detect_sysnrs_probe(void)
 #endif /* KBOX_DEBUG_ABI_PROBE */
 #endif /* !KBOX_UNIT_TEST */
 
-/*
- * Map a host syscall number to its name for diagnostic output.
+/* Map a host syscall number to its name for diagnostic output.
  * Returns "unknown" if the number does not match any entry.
  */
 const char *syscall_name_from_nr(const struct kbox_host_nrs *h, int nr)

--- a/src/web-events.c
+++ b/src/web-events.c
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: MIT */
-/*
- * web-events.c - Event ring buffer for the web observatory.
+/* web-events.c - Event ring buffer for the web observatory.
  *
  * Split ring: 768 entries for sampled routine events, 256 reserved
  * for errors/cancellations.  Tail-based sampling: all errors and
@@ -25,8 +24,7 @@ void kbox_event_ring_init(struct kbox_event_ring *ring)
     memset(ring, 0, sizeof(*ring));
 }
 
-/*
- * Push a routine event (sampled).
+/* Push a routine event (sampled).
  * Overwrites oldest routine entry when full.
  */
 static void ring_push_routine(struct kbox_event_ring *ring,
@@ -38,8 +36,7 @@ static void ring_push_routine(struct kbox_event_ring *ring,
     ring->routine_head = (idx + 1) % KBOX_EVENT_RING_ROUTINE;
 }
 
-/*
- * Push an error/rare event (always captured).
+/* Push an error/rare event (always captured).
  * Overwrites oldest error entry when full.
  */
 static void ring_push_error(struct kbox_event_ring *ring,
@@ -64,8 +61,7 @@ static uint32_t xorshift32(uint32_t *state)
     return x;
 }
 
-/*
- * Returns 1 if this event should be recorded (passes sampling filter).
+/* Returns 1 if this event should be recorded (passes sampling filter).
  *
  * Policy:
  *   - Errors (negative return, nonzero error): always record
@@ -134,8 +130,7 @@ void kbox_event_push_syscall(struct kbox_event_ring *ring,
 
 /* JSON string escaping. */
 
-/*
- * Escape a string for safe JSON embedding.
+/* Escape a string for safe JSON embedding.
  * Handles: " \ and control characters (< 0x20).
  * Returns bytes written (not including NUL).
  */
@@ -194,8 +189,7 @@ int kbox_event_to_json(const struct kbox_event *evt, char *buf, int bufsz)
     return 0;
 }
 
-/*
- * Iterate events from a given sequence number.
+/* Iterate events from a given sequence number.
  * Calls cb for each event with seq >= from_seq.
  * Returns the next sequence number to use.
  */
@@ -205,8 +199,7 @@ uint64_t kbox_event_ring_iterate(const struct kbox_event_ring *ring,
                                             void *userdata),
                                  void *userdata)
 {
-    /*
-     * Scan all slots, emit those with seq > from_seq.
+    /* Scan all slots, emit those with seq > from_seq.
      * O(1024) but only runs on SSE client reads, not the hot path.
      */
     for (int i = 0; i < KBOX_EVENT_RING_SIZE; i++) {

--- a/src/web-server.c
+++ b/src/web-server.c
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: MIT */
-/*
- * web-server.c - Embedded HTTP/1.1 server for the web observatory.
+/* web-server.c - Embedded HTTP/1.1 server for the web observatory.
  *
  * Minimal server supporting:
  *   GET /            -> SPA (compiled-in assets, Phase 2)
@@ -130,8 +129,7 @@ static int parse_request_line(const char *line, struct http_request *req)
 
 /* HTTP responses. */
 
-/*
- * Write all bytes to fd, handling partial writes.
+/* Write all bytes to fd, handling partial writes.
  * Temporarily sets the fd to blocking mode for reliable delivery.
  */
 static void write_all(int fd, const void *buf, size_t len)
@@ -234,8 +232,7 @@ static int start_sse(struct kbox_web_ctx *ctx, int fd)
     if (write(fd, hdr, strlen(hdr)) < 0)
         return -1;
 
-    /*
-     * Remove the FD from epoll; SSE connections are managed
+    /* Remove the FD from epoll; SSE connections are managed
      * exclusively by flush_sse_clients(), not the main read loop.
      * This prevents the main loop from closing the FD on a
      * subsequent read event (which could reuse the FD number).
@@ -322,8 +319,7 @@ static const char *content_type_for(const char *path)
 
 /* Route dispatch. */
 
-/*
- * Handle a single HTTP request.
+/* Handle a single HTTP request.
  * Returns 0 if the connection should be closed, 1 if kept alive (SSE).
  */
 static int handle_request(struct kbox_web_ctx *ctx,

--- a/src/web-telemetry.c
+++ b/src/web-telemetry.c
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: MIT */
-/*
- * web-telemetry.c - Telemetry sampler for the web observatory.
+/* web-telemetry.c - Telemetry sampler for the web observatory.
  *
  * Periodic timer reads LKL-internal /proc files:
  *   Tick (100ms): /proc/stat, /proc/meminfo, /proc/vmstat, /proc/loadavg
@@ -37,8 +36,7 @@ uint64_t kbox_clock_ns(void)
 
 /* LKL /proc reading. */
 
-/*
- * Read a small /proc file from LKL into buf.
+/* Read a small /proc file from LKL into buf.
  * Returns bytes read or 0 on failure.
  */
 static int read_lkl_proc(const struct kbox_sysnrs *s,
@@ -62,8 +60,7 @@ static int read_lkl_proc(const struct kbox_sysnrs *s,
 
 /* /proc parsers. */
 
-/*
- * Parse /proc/stat for context switch count and softirq totals.
+/* Parse /proc/stat for context switch count and softirq totals.
  */
 static void parse_proc_stat(const char *buf,
                             struct kbox_telemetry_snapshot *snap)
@@ -89,8 +86,7 @@ static void parse_proc_stat(const char *buf,
     }
 }
 
-/*
- * Parse /proc/meminfo for memory stats (kB values).
+/* Parse /proc/meminfo for memory stats (kB values).
  */
 static void parse_proc_meminfo(const char *buf,
                                struct kbox_telemetry_snapshot *snap)
@@ -122,8 +118,7 @@ static void parse_proc_meminfo(const char *buf,
         snap->slab = strtoull(p + 5, NULL, 10);
 }
 
-/*
- * Parse /proc/vmstat for page fault counters.
+/* Parse /proc/vmstat for page fault counters.
  */
 static void parse_proc_vmstat(const char *buf,
                               struct kbox_telemetry_snapshot *snap)
@@ -139,8 +134,7 @@ static void parse_proc_vmstat(const char *buf,
         snap->pgmajfault = strtoull(p + 11, NULL, 10);
 }
 
-/*
- * Parse /proc/loadavg.
+/* Parse /proc/loadavg.
  * Format: "0.01 0.05 0.00 1/42 123"
  * Store as fixed-point * 100.
  */
@@ -157,8 +151,7 @@ static void parse_proc_loadavg(const char *buf,
 
 /* Sampler tick. */
 
-/*
- * Per-tick time budget in nanoseconds (5ms).
+/* Per-tick time budget in nanoseconds (5ms).
  * If parsing exceeds this, skip remaining slow-tick files.
  */
 #define TICK_BUDGET_NS (5 * 1000000ULL)
@@ -265,8 +258,7 @@ int kbox_snapshot_to_json(const struct kbox_telemetry_snapshot *snap,
         snap->counters.latency_max_ns);
 }
 
-/*
- * Escape a string for safe JSON embedding.
+/* Escape a string for safe JSON embedding.
  * Handles: " \ and control characters (< 0x20).
  */
 static int escape_json_str(const char *src, char *dst, int dstsz)

--- a/tests/guest/clock-test.c
+++ b/tests/guest/clock-test.c
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: MIT */
-/*
- * Guest test: verify clock_gettime and gettimeofday return plausible values.
+/* Guest test: verify clock_gettime and gettimeofday return plausible values.
  */
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/guest/dup-test.c
+++ b/tests/guest/dup-test.c
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: MIT */
-/*
- * Guest test: verify dup, dup2, dup3, and pipe semantics.
+/* Guest test: verify dup, dup2, dup3, and pipe semantics.
  * Compiled statically and placed in the rootfs.
  */
 #define _GNU_SOURCE

--- a/tests/guest/errno-test.c
+++ b/tests/guest/errno-test.c
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: MIT */
-/*
- * Guest test: verify that errno is correctly propagated from LKL syscalls
+/* Guest test: verify that errno is correctly propagated from LKL syscalls
  * through the seccomp-unotify supervisor.
  */
 #include <errno.h>
@@ -45,8 +44,7 @@ int main(void)
     /* EISDIR: open directory for writing. */
     CHECK_ERRNO(open("/tmp", O_WRONLY), EISDIR);
 
-    /*
-     * Write to read-only FD: skip in kbox.  Shadow FDs (memfds used for
+    /* Write to read-only FD: skip in kbox.  Shadow FDs (memfds used for
      * O_RDONLY regular files to enable mmap) are host-side read-write,
      * so write() succeeds on the host kernel despite O_RDONLY open flags.
      * This is a known shadow FD limitation, not an errno propagation bug.

--- a/tests/guest/net-dns-test.c
+++ b/tests/guest/net-dns-test.c
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: MIT */
-/*
- * Guest test: verify DNS resolution through SLIRP using direct UDP queries.
+/* Guest test: verify DNS resolution through SLIRP using direct UDP queries.
  */
 #include <arpa/inet.h>
 #include <poll.h>

--- a/tests/guest/path-escape-test.c
+++ b/tests/guest/path-escape-test.c
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: MIT */
-/*
- * Guest test: verify that path traversal attempts are confined.
+/* Guest test: verify that path traversal attempts are confined.
  * When running inside kbox's LKL-backed chroot, paths like /../../../
  * should not escape the guest filesystem boundary.
  */
@@ -44,7 +43,7 @@ int main(void)
                   "guest /etc/passwd contains root");
         }
     }
-    /* If open fails, that's also fine -- no escape occurred. */
+    /* If open fails, that is also fine: no escape occurred. */
 
     /* Verify /proc/self/cwd points to / */
     char link[256] = {0};
@@ -58,8 +57,8 @@ int main(void)
     rc = symlink("/../../../../tmp", "/tmp/escape_link");
     if (rc == 0) {
         struct stat st;
-        rc = stat("/tmp/escape_link", &st);
-        /* Whether it resolves or fails, we're still inside kbox. */
+        (void) stat("/tmp/escape_link", &st);
+        /* Whether it resolves or fails, we are still inside kbox. */
         unlink("/tmp/escape_link");
     }
 

--- a/tests/guest/signal-test.c
+++ b/tests/guest/signal-test.c
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: MIT */
-/*
- * Guest test: basic signal handling via rt_sigaction.
+/* Guest test: basic signal handling via rt_sigaction.
  */
 #include <signal.h>
 #include <stdio.h>
@@ -15,7 +14,7 @@
         }                                       \
     } while (0)
 
-static volatile sig_atomic_t got_sigusr1 = 0;
+static volatile sig_atomic_t got_sigusr1;
 
 static void handler(int sig)
 {

--- a/tests/stress/concurrent-io.c
+++ b/tests/stress/concurrent-io.c
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: MIT */
-/*
- * Stress test: concurrent file I/O from multiple threads.
+/* Stress test: concurrent file I/O from multiple threads.
  * Creates 4 threads, each creating a file, writing a pattern, reading it
  * back, and verifying data integrity.
  *
@@ -39,8 +38,7 @@ static void *worker(void *arg)
     snprintf(path, sizeof(path), "/tmp/cio_thread_%d", res->thread_id);
 
     for (iter = 0; iter < ITERATIONS; iter++) {
-        /*
-         * Fill write buffer with a pattern unique to this thread
+        /* Fill write buffer with a pattern unique to this thread
          * and iteration, so cross-thread corruption is detectable.
          */
         unsigned char seed = (unsigned char) (res->thread_id * 37 + iter);

--- a/tests/stress/fd-exhaust.c
+++ b/tests/stress/fd-exhaust.c
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: MIT */
-/*
- * Stress test: open files until EMFILE/ENFILE, verify graceful handling,
+/* Stress test: open files until EMFILE/ENFILE, verify graceful handling,
  * then close all and verify FDs are reusable.
  *
  * Compiled statically, runs inside kbox guest.
@@ -28,8 +27,7 @@ int main(void)
     int count = 0;
     int i;
 
-    /*
-     * Phase 1: open files until we hit the limit.
+    /* Phase 1: open files until we hit the limit.
      * Use /dev/null as the target -- it always exists and does not
      * consume real storage.
      */
@@ -47,16 +45,14 @@ int main(void)
     printf("fd_exhaust: opened %d fds before limit\n", count);
     CHECK(count > 0, "should open at least one fd");
 
-    /*
-     * Phase 2: close all opened FDs.
+    /* Phase 2: close all opened FDs.
      */
     for (i = 0; i < count; i++) {
         int rc = close(fds[i]);
         CHECK(rc == 0, "close should succeed");
     }
 
-    /*
-     * Phase 3: verify FDs are reusable after closing.
+    /* Phase 3: verify FDs are reusable after closing.
      * Open a handful of files to confirm the table freed up.
      */
     int reuse_count = (count < 10) ? count : 10;
@@ -69,8 +65,7 @@ int main(void)
 
     printf("fd_exhaust: reused %d fds after close\n", reuse_count);
 
-    /*
-     * Phase 4: verify double-close returns EBADF, not crash.
+    /* Phase 4: verify double-close returns EBADF, not crash.
      */
     int tmp_fd = open("/dev/null", O_RDONLY);
     CHECK(tmp_fd >= 0, "open for double-close test");

--- a/tests/stress/long-running.c
+++ b/tests/stress/long-running.c
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: MIT */
-/*
- * Stress test: exercise all MVP syscalls in a loop for a configurable
+/* Stress test: exercise all MVP syscalls in a loop for a configurable
  * duration (default 10 seconds).  Each iteration performs:
  *   open, write, read, stat, readdir, mkdir, rmdir, chdir, getcwd,
  *   getpid, clock_gettime, pipe, close
@@ -84,7 +83,7 @@ static int run_one_iteration(int iter)
     DIR *d = opendir(dir_path);
     if (!d)
         return -9;
-    /* Just read entries -- empty dir has . and .. */
+    /* Just read entries; empty dir has . and .. */
     struct dirent *ent;
     int entry_count = 0;
     while ((ent = readdir(d)) != NULL)
@@ -114,7 +113,7 @@ static int run_one_iteration(int iter)
     if (chdir(saved_cwd) != 0)
         return -16;
 
-    /* getpid -- should return a positive value. */
+    /* getpid: should return a positive value. */
     pid_t pid = getpid();
     if (pid <= 0)
         return -17;

--- a/tests/stress/rapid-fork.c
+++ b/tests/stress/rapid-fork.c
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: MIT */
-/*
- * Stress test: fork many short-lived child processes in sequence.
+/* Stress test: fork many short-lived child processes in sequence.
  * Verifies no zombie accumulation, correct wait semantics, and no
  * supervisor resource leaks across 100 fork/exit cycles.
  *
@@ -75,8 +74,7 @@ int main(void)
 
     long elapsed_ms = timespec_diff_ms(&t_start, &t_end);
 
-    /*
-     * Verify no zombies remain.  Try waitpid with WNOHANG -- should
+    /* Verify no zombies remain.  Try waitpid with WNOHANG -- should
      * return 0 (no children) or -1 with ECHILD.
      */
     int status;

--- a/tests/stress/signal-race.c
+++ b/tests/stress/signal-race.c
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: MIT */
-/*
- * Stress test: signal delivery during file I/O.
+/* Stress test: signal delivery during file I/O.
  * Installs a SIGALRM handler that fires every 10ms, then performs
  * file I/O operations continuously for 2 seconds.  Verifies that
  * I/O completes correctly despite signal interrupts (EINTR handling).
@@ -28,7 +27,7 @@
         }                                       \
     } while (0)
 
-static volatile sig_atomic_t signal_count = 0;
+static volatile sig_atomic_t signal_count;
 
 static void alarm_handler(int sig)
 {
@@ -36,8 +35,7 @@ static void alarm_handler(int sig)
     signal_count++;
 }
 
-/*
- * Write with EINTR retry.  Real programs must handle this, and
+/* Write with EINTR retry.  Real programs must handle this, and
  * the supervisor must not corrupt state when signals interrupt
  * a blocked LKL syscall.
  */
@@ -171,8 +169,7 @@ int main(void)
     CHECK(io_ops > 0, "should complete at least one I/O cycle");
     CHECK(signal_count > 0, "should have received at least one signal");
 
-    /*
-     * Allow a small number of transient errors (e.g., EINTR on open),
+    /* Allow a small number of transient errors (e.g., EINTR on open),
      * but the vast majority of operations should succeed.
      */
     if (io_ops > 0 && io_errors > io_ops / 2) {

--- a/tests/unit/test-fd-table.c
+++ b/tests/unit/test-fd-table.c
@@ -181,7 +181,7 @@ static void test_fd_table_find_by_host_fd(void)
     kbox_fd_table_set_host_fd(&t, vfd2, 77);
 
     ASSERT_EQ(kbox_fd_table_find_by_host_fd(&t, 77), vfd2);
-    /* vfd1 has no host_fd set -- should not match */
+    /* vfd1 has no host_fd set; should not match */
     ASSERT_EQ(kbox_fd_table_find_by_host_fd(&t, -1), -1);
 
     (void) vfd1;
@@ -203,7 +203,7 @@ static void test_fd_table_remove_resets_host_fd(void)
     kbox_fd_table_set_host_fd(&t, vfd, 88);
     ASSERT_EQ(kbox_fd_table_get_host_fd(&t, vfd), 88);
     kbox_fd_table_remove(&t, vfd);
-    /* After removal, slot is free -- get_host_fd returns -1. */
+    /* After removal, slot is free; get_host_fd returns -1. */
     ASSERT_EQ(kbox_fd_table_get_host_fd(&t, vfd), -1);
     /* Reverse lookup should also fail. */
     ASSERT_EQ(kbox_fd_table_find_by_host_fd(&t, 88), -1);

--- a/tests/unit/test-path.c
+++ b/tests/unit/test-path.c
@@ -165,8 +165,7 @@ static void test_normalize_join_virtual_escape(void)
     ASSERT_TRUE(kbox_is_lkl_virtual_path(out));
 }
 
-/*
- * Verify that normalize_virtual_relative + normalize_join catches
+/* Verify that normalize_virtual_relative + normalize_join catches
  * the relative path escape variant: "proc/../etc/passwd".
  */
 static void test_normalize_virtual_relative_escape(void)
@@ -206,8 +205,7 @@ static void test_normalize_virtual_relative_escape(void)
     ASSERT_TRUE(kbox_is_lkl_virtual_path(norm));
 }
 
-/*
- * Additional edge cases: deeper escapes, dots within virtual, double slashes,
+/* Additional edge cases: deeper escapes, dots within virtual, double slashes,
  * false virtual prefixes, empty/root paths.
  */
 static void test_normalize_edge_cases(void)

--- a/tests/unit/test-runner.c
+++ b/tests/unit/test-runner.c
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: MIT */
-/*
- * Minimal C test harness.  No external dependencies.
+/* Minimal C test harness.  No external dependencies.
  *
  * Each test file registers tests via TEST_REGISTER() in its
  * init function.  test-runner.c calls all init functions, then

--- a/tests/unit/test-runner.h
+++ b/tests/unit/test-runner.h
@@ -6,8 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-/*
- * Shared test macros.  Included by test_runner.c which defines
+/* Shared test macros.  Included by test_runner.c which defines
  * the actual implementations; individual test files include
  * this header for the macros.
  */


### PR DESCRIPTION
This introduces 'make indent' target that runs clang-format-20, shfmt, and black across the codebase. The shfmt flags (-i 4 -fn -ci -sr -bn) honor .editorconfig settings.

Change-Id: I008a57d2d335a5c866dffa10d3a1d9953906d7fe

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `make indent` to auto-format C, shell, and Python with `clang-format-20`, `shfmt`, and `black`. Reformats the codebase for consistent style; no behavior changes.

- **New Features**
  - `make indent` runs `clang-format-20` (version 20 required), `shfmt` (-i 4 -fn -ci -sr -bn), and `black` over project sources.
  - Adds `.editorconfig` to align shell formatting with `shfmt`.
  - Makefile validates `clang-format` version and locates tools before formatting.

<sup>Written for commit d17545c3c29020b7737e8852c8ea674ffff65dc1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

