### PR TITLE
Modularize build system with Kconfig integration

### DIFF
--- a/.github/workflows/build-kbox.yml
+++ b/.github/workflows/build-kbox.yml
@@ -55,6 +55,9 @@ jobs:
             deps/
           key: rootfs-${{ hashFiles('scripts/alpine-sha256.txt', 'scripts/mkrootfs.sh', 'tests/guest/*.c', 'tests/stress/*.c', 'Makefile') }}
 
+      - name: Configure (defconfig)
+        run: make defconfig
+
       - name: Build kbox (debug + ASAN/UBSAN)
         run: make -j$(nproc)
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.o
+*.d
 *.dSYM/
 *.ext4
 /kbox
@@ -7,6 +8,9 @@ deps/
 lkl-x86_64/
 lkl-aarch64/
 externals/minislirp/
+tools/kconfig/
+.config
+.config.old
 target/
 tests/guest/*-test
 !tests/guest/*-test.c

--- a/Makefile
+++ b/Makefile
@@ -1,208 +1,74 @@
-# kbox - Linux kernel as a library, rootless chroot via seccomp-unotify
-# Build: make [BUILD=release]
-# Test:  make check
+# Build:  make [BUILD=release]
+# Config: make config       (interactive menuconfig)
+#         make defconfig    (all features enabled)
+# Test:   make check
 
-CC       ?= gcc
-CFLAGS   ?=
-LDFLAGS  ?=
-BUILD    ?= debug
+.DEFAULT_GOAL := all
 
-ARCH ?= $(shell uname -m)
+# Kconfig integration
 
-CFLAGS  += -std=gnu11 -D_GNU_SOURCE -Wall -Wextra -Wpedantic -Wshadow
-CFLAGS  += -Wno-unused-parameter
-CFLAGS  += -Iinclude -Isrc
+KCONFIG_DIR  := tools/kconfig
+KCONFIG_CONF := configs/Kconfig
 
-ifeq ($(BUILD),release)
-  CFLAGS  += -O2 -DNDEBUG
-else
-  CFLAGS  += -O0 -g3 -fsanitize=address,undefined -fno-omit-frame-pointer
-  LDFLAGS += -fsanitize=address,undefined
+# Load configuration (safe include -- no error if .config is absent)
+-include .config
+
+# Targets that don't require .config
+CONFIG_TARGETS    := config defconfig oldconfig savedefconfig clean distclean indent \
+                     check-unit fetch-lkl fetch-minislirp install-hooks \
+                     guest-bins stress-bins rootfs
+CONFIG_GENERATORS := config defconfig oldconfig
+
+# Require .config for build targets.
+# Note: 'make defconfig && make' is the correct two-step sequence.
+# 'make defconfig all' does NOT work because .config is parsed at
+# Make startup, before any recipe runs.
+BUILD_GOALS    := $(filter-out $(CONFIG_TARGETS),$(or $(MAKECMDGOALS),all))
+HAS_CONFIG_GEN := $(filter $(CONFIG_GENERATORS),$(MAKECMDGOALS))
+ifneq ($(BUILD_GOALS),)
+ifeq ($(HAS_CONFIG_GEN),)
+ifeq ($(wildcard .config),)
+    $(info )
+    $(info *** Configuration file ".config" not found!)
+    $(info *** Please run 'make config' or 'make defconfig' first.)
+    $(info )
+    $(error Configuration required)
+endif
+endif
 endif
 
-# LKL library
-LKL_DIR  ?= lkl-$(ARCH)
-LKL_LIB   = $(LKL_DIR)/liblkl.a
+# Include modular build fragments
+include mk/toolchain.mk
+include mk/features.mk
+include mk/deps.mk
+include mk/tests.mk
+include mk/format.mk
 
-LDFLAGS += -L$(LKL_DIR) -L$(LKL_DIR)/lib
-LDLIBS   = -llkl -lpthread -ldl -lm -lrt
-
-# Optional: SLIRP networking (set KBOX_HAS_SLIRP=1 to enable)
-ifdef KBOX_HAS_SLIRP
-  SLIRP_DIR  = externals/minislirp
-  SLIRP_HDR  = $(SLIRP_DIR)/src/libslirp.h
-  CFLAGS    += -DKBOX_HAS_SLIRP -I$(SLIRP_DIR)/src
-  SLIRP_SRCS = $(wildcard $(SLIRP_DIR)/src/*.c)
-  SLIRP_OBJS = $(SLIRP_SRCS:.c=.o)
-endif
-
-# Optional: Web observatory (set KBOX_HAS_WEB=1 to enable)
-ifdef KBOX_HAS_WEB
-  CFLAGS    += -DKBOX_HAS_WEB
-  WEB_ASSET_SRC = $(SRC_DIR)/web-assets.c
-endif
-
-# Source files
-SRC_DIR  = src
-SRCS     = $(SRC_DIR)/main.c \
-           $(SRC_DIR)/cli.c \
-           $(SRC_DIR)/syscall-nr.c \
-           $(SRC_DIR)/lkl-wrap.c \
-           $(SRC_DIR)/fd-table.c \
-           $(SRC_DIR)/procmem.c \
-           $(SRC_DIR)/path.c \
-           $(SRC_DIR)/identity.c \
-           $(SRC_DIR)/elf.c \
-           $(SRC_DIR)/mount.c \
-           $(SRC_DIR)/probe.c \
-           $(SRC_DIR)/image.c \
-           $(SRC_DIR)/seccomp-bpf.c \
-           $(SRC_DIR)/seccomp-notify.c \
-           $(SRC_DIR)/shadow-fd.c \
-           $(SRC_DIR)/seccomp-dispatch.c \
-           $(SRC_DIR)/seccomp-supervisor.c \
-           $(SRC_DIR)/net-slirp.c \
-           $(SRC_DIR)/web-telemetry.c \
-           $(SRC_DIR)/web-events.c \
-           $(SRC_DIR)/web-server.c
-
-ifdef KBOX_HAS_WEB
-  SRCS    += $(WEB_ASSET_SRC)
-endif
-
-ifdef KBOX_HAS_SLIRP
-  SRCS    += $(SLIRP_SRCS)
-endif
-
-OBJS     = $(SRCS:.c=.o)
-TARGET   = kbox
-
-# Unit test files (no LKL dependency)
-TEST_DIR   = tests/unit
-TEST_SRCS  = $(TEST_DIR)/test-runner.c \
-             $(TEST_DIR)/test-fd-table.c \
-             $(TEST_DIR)/test-path.c \
-             $(TEST_DIR)/test-identity.c \
-             $(TEST_DIR)/test-syscall-nr.c \
-             $(TEST_DIR)/test-elf.c
-
-# Unit tests link only the pure-computation sources (no LKL)
-TEST_SUPPORT_SRCS = $(SRC_DIR)/fd-table.c \
-                    $(SRC_DIR)/path.c \
-                    $(SRC_DIR)/identity.c \
-                    $(SRC_DIR)/syscall-nr.c \
-                    $(SRC_DIR)/elf.c
-
-TEST_OBJS    = $(TEST_SRCS:.c=.o) $(TEST_SUPPORT_SRCS:.c=.o)
-TEST_TARGET  = tests/unit/test-runner
-
-# Guest test programs (compiled statically, run inside kbox)
-GUEST_DIR    = tests/guest
-GUEST_SRCS   = $(wildcard $(GUEST_DIR)/*-test.c)
-GUEST_BINS   = $(GUEST_SRCS:.c=)
-
-# Stress test programs (compiled statically, run inside kbox)
-STRESS_DIR   = tests/stress
-STRESS_SRCS  = $(wildcard $(STRESS_DIR)/*.c)
-STRESS_BINS  = $(STRESS_SRCS:.c=)
-
-# Rootfs image
-ROOTFS       = alpine.ext4
-
-# ---- Top-level targets ----
-
-.PHONY: all clean check check-unit check-integration check-stress guest-bins stress-bins rootfs fetch-lkl fetch-minislirp install-hooks web-assets indent
+# Top-level targets
+.PHONY: all clean distclean config defconfig oldconfig savedefconfig install-hooks
 
 all: $(TARGET)
-ifneq ($(wildcard .git),)
+ifneq ($(wildcard .git/hooks),)
 all: | .git/hooks/pre-commit
 endif
 
-$(TARGET): $(OBJS) | $(LKL_LIB)
-	$(CC) $(LDFLAGS) -o $@ $(OBJS) $(LDLIBS)
+$(TARGET): $(OBJS) $(LKL_LIB)
+	@echo "  LD      $@"
+	$(Q)$(CC) $(LDFLAGS) -o $@ $(OBJS) $(LDLIBS)
+
+# Rebuild all objects when .config changes (CFLAGS may differ).
+$(OBJS): $(wildcard .config)
 
 %.o: %.c
-	$(CC) $(CFLAGS) -c -o $@ $<
+	@echo "  CC      $<"
+	$(Q)$(CC) $(CFLAGS) -MMD -MP -c -o $@ $<
 
 # Auto-install git hooks on first build (skipped in worktrees where .git is a file).
 .git/hooks/pre-commit: scripts/pre-commit.hook
-	@if [ -d .git/hooks ]; then $(MAKE) -s install-hooks; fi
+	$(Q)if [ -d .git/hooks ]; then $(MAKE) install-hooks; fi
 
-# Auto-fetch LKL if missing
-$(LKL_LIB):
-	@echo "LKL library not found at $(LKL_DIR). Fetching..."
-	./scripts/fetch-lkl.sh $(ARCH)
-
-# Auto-fetch minislirp if missing (shallow clone, no submodule).
-# $(wildcard) evaluates at parse time, so if minislirp has not been
-# fetched yet SLIRP_SRCS is empty.  Guard: fetch and re-exec make so
-# the wildcard picks up the newly-cloned sources.
-ifdef KBOX_HAS_SLIRP
-# Auto-fetch minislirp if the header is missing and a build target
-# was requested (skip for clean/fetch-only goals).
-ifneq ($(filter clean,$(MAKECMDGOALS)),clean)
-ifeq ($(wildcard $(SLIRP_HDR)),)
-$(shell ./scripts/fetch-minislirp.sh >&2)
-SLIRP_SRCS = $(wildcard $(SLIRP_DIR)/src/*.c)
-SLIRP_OBJS = $(SLIRP_SRCS:.c=.o)
-endif
-endif
-
-fetch-minislirp:
-	./scripts/fetch-minislirp.sh
-endif
-
-# ---- Test targets ----
-
-check: check-unit check-integration check-stress
-
-check-unit: $(TEST_TARGET)
-	./$(TEST_TARGET)
-
-# Unit tests are built WITHOUT linking LKL.
-# We define LKL stubs for functions referenced by test support code.
-$(TEST_TARGET): $(TEST_SRCS) $(TEST_SUPPORT_SRCS)
-	$(CC) $(CFLAGS) -DKBOX_UNIT_TEST -o $@ $^ $(LDFLAGS)
-
-check-integration: $(TARGET) guest-bins stress-bins $(ROOTFS)
-	./scripts/run-tests.sh ./$(TARGET) $(ROOTFS)
-
-check-stress: $(TARGET) stress-bins $(ROOTFS)
-	./scripts/run-stress.sh ./$(TARGET) $(ROOTFS) || \
-	  echo "(stress test failures are non-blocking -- see TODO.md)"
-
-# ---- Guest / stress binaries (static, no ASAN) ----
-# These are cross-compiled on Linux and placed into the rootfs.
-# They must be statically linked and cannot use sanitizers.
-
-guest-bins: $(GUEST_BINS)
-
-$(GUEST_DIR)/%-test: $(GUEST_DIR)/%-test.c
-	$(CC) -std=gnu11 -Wall -Wextra -O2 -static -o $@ $<
-
-stress-bins: $(STRESS_BINS)
-
-$(STRESS_DIR)/%: $(STRESS_DIR)/%.c
-	$(CC) -std=gnu11 -Wall -Wextra -O2 -static -pthread -o $@ $<
-
-# ---- Rootfs ----
-
-rootfs: $(ROOTFS)
-
-$(ROOTFS): scripts/mkrootfs.sh scripts/alpine-sha256.txt $(GUEST_BINS) $(STRESS_BINS)
-	ALPINE_ARCH=$(ARCH) ./scripts/mkrootfs.sh
-
-# ---- Utilities ----
-
-# Fetch LKL from nightly release if not cached locally.
-# To force re-download: rm -rf lkl-x86_64 && make fetch-lkl
-fetch-lkl:
-	./scripts/fetch-lkl.sh $(ARCH)
-
-# Install git hooks from scripts/*.hook into .git/hooks/.
-# Skips hooks that already exist (preserves user customizations).
 install-hooks:
-	@for hook in scripts/*.hook; do \
+	$(Q)for hook in scripts/*.hook; do \
 	    name=$$(basename "$$hook" .hook); \
 	    if [ ! -e .git/hooks/"$$name" ] && [ ! -L .git/hooks/"$$name" ]; then \
 	        ln -s ../../"$$hook" .git/hooks/"$$name"; \
@@ -210,55 +76,41 @@ install-hooks:
 	    fi; \
 	done
 
-# Generate compiled-in web assets from web/ directory.
-# Re-run when any web/ file changes.
-ifdef KBOX_HAS_WEB
-WEB_SRCS_ALL = $(shell find web -type f \( -name '*.html' -o -name '*.css' -o -name '*.js' -o -name '*.svg' \) 2>/dev/null)
-$(WEB_ASSET_SRC): $(WEB_SRCS_ALL) scripts/gen-web-assets.sh
-	./scripts/gen-web-assets.sh
-web-assets: $(WEB_ASSET_SRC)
-endif
+# Kconfig targets
 
-# ---- Formatting ----
+# Fetch Kconfiglib on demand, then run the appropriate tool.
+config: | $(KCONFIG_DIR)/menuconfig.py
+	$(Q)KCONFIG_CONFIG=.config python3 $(KCONFIG_DIR)/menuconfig.py $(KCONFIG_CONF)
+	@echo "  CONFIG  .config"
 
-CLANG_FORMAT := $(shell command -v clang-format-20 2>/dev/null || \
-                        command -v clang-format 2>/dev/null)
-SHFMT        := shfmt
-BLACK        := black
+defconfig: | $(KCONFIG_DIR)/menuconfig.py
+	@echo "  CONFIG  defconfig"
+	$(Q)KCONFIG_CONFIG=.config python3 $(KCONFIG_DIR)/defconfig.py --kconfig $(KCONFIG_CONF) configs/defconfig
 
-C_SRCS_FMT  := $(wildcard src/*.c src/*.h include/kbox/*.h \
-                tests/unit/*.c tests/unit/*.h \
-                tests/guest/*.c tests/stress/*.c)
-SH_SRCS_FMT := $(wildcard scripts/*.sh)
-PY_SRCS_FMT := $(wildcard scripts/gdb/*.py)
+oldconfig: | $(KCONFIG_DIR)/menuconfig.py
+	@echo "  CONFIG  oldconfig"
+	$(Q)KCONFIG_CONFIG=.config python3 $(KCONFIG_DIR)/oldconfig.py $(KCONFIG_CONF)
 
-indent:
-ifeq ($(CLANG_FORMAT),)
-	$(error clang-format not found; install clang-format or clang-format-20)
-endif
-	@$(CLANG_FORMAT) --version | grep -q 'version 20' || \
-	  { echo "error: clang-format version 20 required"; exit 1; }
-	$(CLANG_FORMAT) -i $(C_SRCS_FMT)
-	$(SHFMT) -i 4 -fn -ci -sr -bn -w $(SH_SRCS_FMT)
-	$(BLACK) -q $(PY_SRCS_FMT)
+savedefconfig: | $(KCONFIG_DIR)/menuconfig.py
+	@echo "  CONFIG  savedefconfig"
+	$(Q)KCONFIG_CONFIG=.config python3 $(KCONFIG_DIR)/savedefconfig.py --kconfig $(KCONFIG_CONF) --out configs/defconfig
+
+$(KCONFIG_DIR)/menuconfig.py:
+	@echo "  FETCH   kconfiglib"
+	$(Q)scripts/fetch-kconfiglib.sh
+
+# Clean
 
 clean:
-	rm -f $(OBJS) $(TARGET) $(TEST_TARGET) $(TEST_DIR)/*.o
-	rm -f src/*.o src/web-assets.c
-	rm -f $(GUEST_BINS) $(STRESS_BINS)
+	@echo "  CLEAN"
+	$(Q)rm -f $(OBJS) $(OBJS:.o=.d) $(TARGET) $(TEST_TARGET) $(TEST_DIR)/*.o
+	$(Q)rm -f src/*.o src/*.d src/web-assets.c
+	$(Q)rm -f $(GUEST_BINS) $(STRESS_BINS)
 
-# ---- Dependencies ----
-# Auto-generate with gcc -MM if needed; keep it simple for now.
-$(SRC_DIR)/main.o: include/kbox/cli.h include/kbox/image.h
-$(SRC_DIR)/cli.o: include/kbox/cli.h
-$(SRC_DIR)/probe.o: include/kbox/probe.h src/seccomp-defs.h
-$(SRC_DIR)/image.o: include/kbox/image.h include/kbox/mount.h include/kbox/identity.h include/kbox/probe.h src/lkl-wrap.h src/net.h src/seccomp.h src/shadow-fd.h
-$(SRC_DIR)/shadow-fd.o: src/shadow-fd.h src/lkl-wrap.h src/syscall-nr.h
-$(SRC_DIR)/seccomp-dispatch.o: src/seccomp.h src/seccomp-defs.h src/fd-table.h src/lkl-wrap.h src/procmem.h include/kbox/path.h include/kbox/identity.h src/shadow-fd.h src/net.h
-$(SRC_DIR)/seccomp-supervisor.o: src/seccomp.h src/seccomp-defs.h src/syscall-nr.h
-$(SRC_DIR)/seccomp-bpf.o: src/seccomp.h src/seccomp-defs.h src/syscall-nr.h
-$(SRC_DIR)/seccomp-notify.o: src/seccomp.h src/seccomp-defs.h
-$(SRC_DIR)/net-slirp.o: src/net.h src/lkl-wrap.h src/syscall-nr.h
-$(SRC_DIR)/web-telemetry.o: src/web.h src/lkl-wrap.h src/syscall-nr.h
-$(SRC_DIR)/web-events.o: src/web.h
-$(SRC_DIR)/web-server.o: src/web.h src/fd-table.h src/lkl-wrap.h src/syscall-nr.h
+distclean: clean
+	@echo "  CLEAN   distclean"
+	$(Q)rm -f .config .config.old
+	$(Q)rm -rf $(KCONFIG_DIR)
+
+# Auto-generated header dependencies (-MMD -MP writes .d alongside .o)
+-include $(OBJS:.o=.d)

--- a/configs/Kconfig
+++ b/configs/Kconfig
@@ -1,0 +1,65 @@
+# kbox Configuration
+
+mainmenu "kbox Configuration"
+
+# Feature Selection
+
+menu "Features"
+
+config HAS_SLIRP
+    bool "SLIRP networking (userspace TCP/IP)"
+    default y
+    help
+      Enable userspace networking via minislirp.
+      Provides TCP/IP connectivity for guest processes without
+      root privileges or TUN/TAP devices.
+      The minislirp library is fetched automatically if missing.
+
+config HAS_WEB
+    bool "Web observatory dashboard"
+    default y
+    help
+      Enable the built-in web telemetry server.
+      Provides a real-time dashboard for monitoring syscall
+      activity, FD table state, and performance counters.
+      Serves compiled-in HTML/CSS/JS assets on a local port.
+
+endmenu
+
+# Build Options
+
+menu "Build Options"
+
+choice
+    prompt "Build Mode"
+    default BUILD_DEBUG
+
+config BUILD_DEBUG
+    bool "Debug (ASAN/UBSAN, -O0 -g3)"
+    help
+      Development build with AddressSanitizer and
+      UndefinedBehaviorSanitizer enabled.
+      Slower execution but catches memory errors.
+
+config BUILD_RELEASE
+    bool "Release (-O2, no sanitizers)"
+    help
+      Optimized build for production use.
+      No sanitizers, no debug symbols.
+
+endchoice
+
+config LKL_DIR
+    string "LKL library directory"
+    default ""
+    help
+      Path to the LKL (Linux Kernel Library) directory.
+      Leave empty to use the default: lkl-$(ARCH).
+      The LKL library is fetched automatically if missing.
+
+endmenu
+
+# Marker for configured builds
+config CONFIGURED
+    bool
+    default y

--- a/configs/defconfig
+++ b/configs/defconfig
@@ -1,0 +1,7 @@
+# kbox default configuration -- all features enabled
+CONFIG_HAS_SLIRP=y
+CONFIG_HAS_WEB=y
+CONFIG_BUILD_DEBUG=y
+# CONFIG_BUILD_RELEASE is not set
+CONFIG_LKL_DIR=""
+CONFIG_CONFIGURED=y

--- a/mk/deps.mk
+++ b/mk/deps.mk
@@ -1,0 +1,43 @@
+# External dependency fetching (LKL, minislirp)
+
+# Auto-fetch LKL if missing
+$(LKL_LIB):
+	@echo "  FETCH   lkl"
+	$(Q)./scripts/fetch-lkl.sh $(ARCH)
+
+.PHONY: fetch-lkl
+fetch-lkl:
+	@echo "  FETCH   lkl"
+	$(Q)./scripts/fetch-lkl.sh $(ARCH)
+
+# Auto-fetch minislirp if missing (shallow clone, no submodule).
+# $(wildcard) evaluates at parse time, so if minislirp has not been fetched yet
+# SLIRP_SRCS is empty. Guard: fetch and re-eval so the wildcard picks up
+# the newly-cloned sources.
+ifeq ($(CONFIG_HAS_SLIRP),y)
+ifneq ($(filter clean distclean config defconfig oldconfig savedefconfig indent,$(MAKECMDGOALS)),)
+else
+ifeq ($(wildcard $(SLIRP_HDR)),)
+$(shell ./scripts/fetch-minislirp.sh >&2)
+SLIRP_SRCS = $(shell ls $(SLIRP_DIR)/src/*.c 2>/dev/null)
+SLIRP_OBJS = $(SLIRP_SRCS:.c=.o)
+endif
+endif
+
+.PHONY: fetch-minislirp
+fetch-minislirp:
+	@echo "  FETCH   minislirp"
+	$(Q)scripts/fetch-minislirp.sh
+endif
+
+# Generate compiled-in web assets from web/ directory.
+# Re-run when any web/ file changes.
+ifeq ($(CONFIG_HAS_WEB),y)
+WEB_SRCS_ALL = $(wildcard web/*.html web/*.css web/*.js web/*.svg)
+$(WEB_ASSET_SRC): $(WEB_SRCS_ALL) scripts/gen-web-assets.sh
+	@echo "  GEN     $@"
+	$(Q)scripts/gen-web-assets.sh
+
+.PHONY: web-assets
+web-assets: $(WEB_ASSET_SRC)
+endif

--- a/mk/features.mk
+++ b/mk/features.mk
@@ -1,0 +1,48 @@
+# Feature-conditional source files and flags
+
+SRC_DIR  = src
+
+# Core sources (always built).
+# net-slirp.c, web-*.c have #ifdef guards and compile to empty TUs when their
+# feature is disabled -- no need to exclude them.
+SRCS     = $(SRC_DIR)/main.c \
+           $(SRC_DIR)/cli.c \
+           $(SRC_DIR)/syscall-nr.c \
+           $(SRC_DIR)/lkl-wrap.c \
+           $(SRC_DIR)/fd-table.c \
+           $(SRC_DIR)/procmem.c \
+           $(SRC_DIR)/path.c \
+           $(SRC_DIR)/identity.c \
+           $(SRC_DIR)/elf.c \
+           $(SRC_DIR)/mount.c \
+           $(SRC_DIR)/probe.c \
+           $(SRC_DIR)/image.c \
+           $(SRC_DIR)/seccomp-bpf.c \
+           $(SRC_DIR)/seccomp-notify.c \
+           $(SRC_DIR)/shadow-fd.c \
+           $(SRC_DIR)/seccomp-dispatch.c \
+           $(SRC_DIR)/seccomp-supervisor.c \
+           $(SRC_DIR)/net-slirp.c \
+           $(SRC_DIR)/web-telemetry.c \
+           $(SRC_DIR)/web-events.c \
+           $(SRC_DIR)/web-server.c
+
+# SLIRP networking
+ifeq ($(CONFIG_HAS_SLIRP),y)
+  SLIRP_DIR  = externals/minislirp
+  SLIRP_HDR  = $(SLIRP_DIR)/src/libslirp.h
+  CFLAGS    += -DKBOX_HAS_SLIRP -I$(SLIRP_DIR)/src
+  SLIRP_SRCS = $(wildcard $(SLIRP_DIR)/src/*.c)
+  SLIRP_OBJS = $(SLIRP_SRCS:.c=.o)
+  SRCS      += $(SLIRP_SRCS)
+endif
+
+# Web observatory
+ifeq ($(CONFIG_HAS_WEB),y)
+  CFLAGS       += -DKBOX_HAS_WEB
+  WEB_ASSET_SRC = $(SRC_DIR)/web-assets.c
+  SRCS         += $(WEB_ASSET_SRC)
+endif
+
+OBJS     = $(SRCS:.c=.o)
+TARGET   = kbox

--- a/mk/format.mk
+++ b/mk/format.mk
@@ -1,0 +1,27 @@
+# mk/format.mk - Code formatting rules
+
+CLANG_FORMAT := $(shell command -v clang-format-20 2>/dev/null || \
+                        command -v clang-format 2>/dev/null)
+SHFMT        := shfmt
+BLACK        := black
+
+C_SRCS_FMT  := $(wildcard src/*.c src/*.h include/kbox/*.h \
+                tests/unit/*.c tests/unit/*.h \
+                tests/guest/*.c tests/stress/*.c)
+SH_SRCS_FMT := $(wildcard scripts/*.sh)
+PY_SRCS_FMT := $(wildcard scripts/gdb/*.py)
+
+indent:
+ifeq ($(CLANG_FORMAT),)
+	$(error clang-format not found; install clang-format or clang-format-20)
+endif
+	$(Q)$(CLANG_FORMAT) --version | grep -q 'version 20' || \
+	  { echo "error: clang-format version 20 required"; exit 1; }
+	@echo "  INDENT  C sources"
+	$(Q)$(CLANG_FORMAT) -i $(C_SRCS_FMT)
+	@echo "  INDENT  shell scripts"
+	$(Q)$(SHFMT) -i 4 -fn -ci -sr -bn -w $(SH_SRCS_FMT)
+	@echo "  INDENT  Python scripts"
+	$(Q)$(BLACK) -q $(PY_SRCS_FMT)
+
+.PHONY: indent

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -1,0 +1,81 @@
+# mk/tests.mk - Test targets (unit, integration, stress, guest binaries)
+
+# Unit test files (no LKL dependency)
+TEST_DIR   = tests/unit
+TEST_SRCS  = $(TEST_DIR)/test-runner.c \
+             $(TEST_DIR)/test-fd-table.c \
+             $(TEST_DIR)/test-path.c \
+             $(TEST_DIR)/test-identity.c \
+             $(TEST_DIR)/test-syscall-nr.c \
+             $(TEST_DIR)/test-elf.c
+
+# Unit tests link only the pure-computation sources (no LKL)
+TEST_SUPPORT_SRCS = $(SRC_DIR)/fd-table.c \
+                    $(SRC_DIR)/path.c \
+                    $(SRC_DIR)/identity.c \
+                    $(SRC_DIR)/syscall-nr.c \
+                    $(SRC_DIR)/elf.c
+
+TEST_TARGET  = tests/unit/test-runner
+
+# Guest test programs (compiled statically, run inside kbox)
+GUEST_DIR    = tests/guest
+GUEST_SRCS   = $(wildcard $(GUEST_DIR)/*-test.c)
+GUEST_BINS   = $(GUEST_SRCS:.c=)
+
+# Stress test programs (compiled statically, run inside kbox)
+STRESS_DIR   = tests/stress
+STRESS_SRCS  = $(wildcard $(STRESS_DIR)/*.c)
+STRESS_BINS  = $(STRESS_SRCS:.c=)
+
+# Rootfs image
+ROOTFS       = alpine.ext4
+
+# ---- Test targets ----
+
+check: check-unit check-integration check-stress
+
+check-unit: $(TEST_TARGET)
+	@echo "  RUN     check-unit"
+	$(Q)./$(TEST_TARGET)
+
+# Unit tests are built WITHOUT linking LKL.
+# We define LKL stubs for functions referenced by test support code.
+$(TEST_TARGET): $(TEST_SRCS) $(TEST_SUPPORT_SRCS) $(wildcard .config)
+	@echo "  LD      $@"
+	$(Q)$(CC) $(CFLAGS) -DKBOX_UNIT_TEST -o $@ $(TEST_SRCS) $(TEST_SUPPORT_SRCS) $(LDFLAGS)
+
+check-integration: $(TARGET) guest-bins stress-bins $(ROOTFS)
+	@echo "  RUN     check-integration"
+	$(Q)./scripts/run-tests.sh ./$(TARGET) $(ROOTFS)
+
+check-stress: $(TARGET) stress-bins $(ROOTFS)
+	@echo "  RUN     check-stress"
+	$(Q)./scripts/run-stress.sh ./$(TARGET) $(ROOTFS) || \
+	  echo "(stress test failures are non-blocking -- see TODO.md)"
+
+# ---- Guest / stress binaries (static, no ASAN) ----
+# These are cross-compiled on Linux and placed into the rootfs.
+# They must be statically linked and cannot use sanitizers.
+
+guest-bins: $(GUEST_BINS)
+
+$(GUEST_DIR)/%-test: $(GUEST_DIR)/%-test.c
+	@echo "  CC      $<"
+	$(Q)$(CC) -std=gnu11 -Wall -Wextra -O2 -static -o $@ $<
+
+stress-bins: $(STRESS_BINS)
+
+$(STRESS_DIR)/%: $(STRESS_DIR)/%.c
+	@echo "  CC      $<"
+	$(Q)$(CC) -std=gnu11 -Wall -Wextra -O2 -static -pthread -o $@ $<
+
+# ---- Rootfs ----
+
+rootfs: $(ROOTFS)
+
+$(ROOTFS): scripts/mkrootfs.sh scripts/alpine-sha256.txt $(GUEST_BINS) $(STRESS_BINS)
+	@echo "  GEN     $@"
+	$(Q)ALPINE_ARCH=$(ARCH) ./scripts/mkrootfs.sh
+
+.PHONY: check check-unit check-integration check-stress guest-bins stress-bins rootfs

--- a/mk/toolchain.mk
+++ b/mk/toolchain.mk
@@ -1,0 +1,52 @@
+# mk/toolchain.mk - Compiler detection and Kconfig-derived flags
+
+CC       ?= gcc
+CFLAGS   ?=
+LDFLAGS  ?=
+
+ARCH ?= $(shell uname -m)
+
+# Verbosity: silent by default, 'make V=1' shows full commands.
+ifeq ($(V),1)
+  Q :=
+else
+  Q := @
+  MAKEFLAGS += --no-print-directory
+endif
+
+# kbox is Linux-only. Bail if the compiler does not target Linux.
+# Skip the check for targets that don't compile (config, clean, indent, etc.).
+ifneq ($(BUILD_GOALS),)
+CC_TARGET := $(shell $(CC) -dumpmachine 2>/dev/null)
+ifeq ($(findstring linux,$(CC_TARGET)),)
+  $(error $(CC) targets '$(CC_TARGET)', not Linux. kbox requires a Linux-targeting compiler)
+endif
+endif
+
+# Base C flags (always applied)
+CFLAGS  += -std=gnu11 -D_GNU_SOURCE -Wall -Wextra -Wpedantic -Wshadow
+CFLAGS  += -Wno-unused-parameter
+CFLAGS  += -Iinclude -Isrc
+
+# Build mode from Kconfig (fallback to BUILD= for unconfigured builds)
+ifeq ($(CONFIG_BUILD_RELEASE),y)
+  CFLAGS  += -O2 -DNDEBUG
+else ifeq ($(BUILD),release)
+  CFLAGS  += -O2 -DNDEBUG
+else
+  CFLAGS  += -O0 -g3 -fsanitize=address,undefined -fno-omit-frame-pointer
+  LDFLAGS += -fsanitize=address,undefined
+endif
+
+# LKL library location (from Kconfig or command line)
+ifdef CONFIG_LKL_DIR
+  LKL_DIR := $(patsubst "%",%,$(CONFIG_LKL_DIR))
+endif
+ifeq ($(strip $(LKL_DIR)),)
+  LKL_DIR := lkl-$(ARCH)
+endif
+
+LKL_LIB   = $(LKL_DIR)/liblkl.a
+
+LDFLAGS += -L$(LKL_DIR) -L$(LKL_DIR)/lib
+LDLIBS   = -llkl -lpthread -ldl -lm -lrt

--- a/scripts/fetch-kconfiglib.sh
+++ b/scripts/fetch-kconfiglib.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Fetch Kconfiglib into tools/kconfig/ if not already present.
+# Shallow-clones the official repo to avoid pulling full history.
+
+set -euo pipefail
+
+KCONFIG_DIR="tools/kconfig"
+KCONFIG_REPO="https://github.com/sysprog21/Kconfiglib.git"
+KCONFIG_REF="4dbd20b5193a"
+
+# Re-clone if present but pinned to wrong commit.
+if [ -f "$KCONFIG_DIR/menuconfig.py" ]; then
+    CURRENT_REF=$(git -C "$KCONFIG_DIR" rev-parse --short=12 HEAD 2> /dev/null || true)
+    if [ "$CURRENT_REF" = "$KCONFIG_REF" ]; then
+        exit 0
+    fi
+    echo "Kconfiglib version mismatch ($CURRENT_REF != $KCONFIG_REF), re-fetching..."
+    rm -rf "$KCONFIG_DIR"
+fi
+
+echo "Fetching Kconfiglib ($KCONFIG_REF)..."
+rm -rf "$KCONFIG_DIR"
+mkdir -p "$(dirname "$KCONFIG_DIR")"
+git clone "$KCONFIG_REPO" "$KCONFIG_DIR"
+git -C "$KCONFIG_DIR" checkout "$KCONFIG_REF"
+echo "Kconfiglib installed at $KCONFIG_DIR (pinned to $KCONFIG_REF)"


### PR DESCRIPTION
This splits monolithic Makefile into mk/ fragments (toolchain, features, deps, tests, format) and add Kconfiglib-based configuration via 'make config' (interactive menuconfig) or 'make defconfig'.

Features (SLIRP networking, web observatory) are enabled by default and toggled via CONFIG_HAS_WEB in .config. The build mode (debug/release) is also configurable through Kconfig.

Kconfiglib is fetched on demand from sysprog21/Kconfiglib via shallow clone into tools/kconfig/, cleaned by 'make distclean'.

Change-Id: I719856353c77c9c69872b9180fa6d6296b732a6c

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Modularized the build into `mk/` fragments and integrated `Kconfiglib` so features and build mode are configured via `make config`/`make defconfig`. Builds now require a `.config`; run `make defconfig && make` or use the interactive `make config`.

- **New Features**
  - `make config` (menuconfig), `make defconfig`, `make oldconfig`, and `make savedefconfig` generate and manage `.config` (defaults: `CONFIG_HAS_SLIRP=y`, `CONFIG_HAS_WEB=y`, debug build).
  - Feature flags: `CONFIG_HAS_SLIRP`, `CONFIG_HAS_WEB`; build mode: `CONFIG_BUILD_DEBUG` or `CONFIG_BUILD_RELEASE`; optional `CONFIG_LKL_DIR`.
  - On-demand `Kconfiglib` download, pinned into `tools/kconfig/`; removed by `make distclean`. LKL and `minislirp` still auto-fetched when enabled.
  - `.config` changes trigger object rebuilds.

- **Migration**
  - Run `make defconfig` once, then `make`. Use two steps (e.g., `make defconfig && make`), not `make defconfig all`.
  - CI updated to run `make defconfig` before building/tests.
  - Use `make oldconfig` when new options are added; `make distclean` resets `.config` and removes `tools/kconfig/`.

<sup>Written for commit cf507ae9a32153e5c547d88ef3dcbab86f95d274. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

