### PR TITLE
Close FD gap in [1024, 32768)

### DIFF
--- a/src/fd-table.h
+++ b/src/fd-table.h
@@ -16,8 +16,8 @@ struct kbox_sysnrs; /* forward declaration */
 
 #define KBOX_FD_BASE 32768
 #define KBOX_FD_TABLE_MAX 4096
-/* redirect slots for FDs 0..1023 (dup2 targets) */
-#define KBOX_LOW_FD_MAX 1024
+/* redirect slots for FDs 0..32767 (dup2 targets) */
+#define KBOX_LOW_FD_MAX 32768
 #define KBOX_FD_TABLE_CAPACITY (KBOX_FD_TABLE_MAX + KBOX_LOW_FD_MAX)
 
 struct kbox_fd_entry {

--- a/tests/unit/test-fd-table.c
+++ b/tests/unit/test-fd-table.c
@@ -94,9 +94,8 @@ static void test_fd_table_out_of_range(void)
 {
     struct kbox_fd_table t;
     kbox_fd_table_init(&t);
-    /* Gap between low_fds and high range */
-    ASSERT_EQ(kbox_fd_table_get_lkl(&t, KBOX_LOW_FD_MAX), -1);
-    ASSERT_EQ(kbox_fd_table_get_lkl(&t, KBOX_FD_BASE - 1), -1);
+    /* Under range */
+    ASSERT_EQ(kbox_fd_table_get_lkl(&t, -1), -1);
     /* Above range */
     ASSERT_EQ(kbox_fd_table_get_lkl(&t, KBOX_FD_BASE + KBOX_FD_TABLE_MAX), -1);
 }
@@ -116,15 +115,23 @@ static void test_fd_table_insert_at_low_range(void)
     ASSERT_EQ(rc, 0);
     ASSERT_EQ(kbox_fd_table_get_lkl(&t, 100), 55);
 
-    /* Boundary: FD 1023 (last valid low slot) */
-    rc = kbox_fd_table_insert_at(&t, KBOX_LOW_FD_MAX - 1, 77, 1);
+    /* Mid-range: FD 1023 */
+    rc = kbox_fd_table_insert_at(&t, 1023, 77, 1);
     ASSERT_EQ(rc, 0);
-    ASSERT_EQ(kbox_fd_table_get_lkl(&t, KBOX_LOW_FD_MAX - 1), 77);
-    ASSERT_TRUE(kbox_fd_table_mirror_tty(&t, KBOX_LOW_FD_MAX - 1));
+    ASSERT_EQ(kbox_fd_table_get_lkl(&t, 1023), 77);
+    ASSERT_TRUE(kbox_fd_table_mirror_tty(&t, 1023));
 
-    /* Gap: FD 1024 should fail */
-    rc = kbox_fd_table_insert_at(&t, KBOX_LOW_FD_MAX, 66, 0);
-    ASSERT_EQ(rc, -1);
+    /* Mid-range: FD 10000 */
+    rc = kbox_fd_table_insert_at(&t, 10000, 33, 1);
+    ASSERT_EQ(rc, 0);
+    ASSERT_EQ(kbox_fd_table_get_lkl(&t, 10000), 33);
+    ASSERT_TRUE(kbox_fd_table_mirror_tty(&t, 10000));
+
+    /* Boundary: FD 32767 (the last low-range slot) */
+    rc = kbox_fd_table_insert_at(&t, KBOX_LOW_FD_MAX - 1, 66, 0);
+    ASSERT_EQ(rc, 0);
+    ASSERT_EQ(kbox_fd_table_get_lkl(&t, KBOX_LOW_FD_MAX - 1), 66);
+    ASSERT_TRUE(!kbox_fd_table_mirror_tty(&t, KBOX_LOW_FD_MAX - 1));
 
     /* Low-range remove */
     long old = kbox_fd_table_remove(&t, 100);


### PR DESCRIPTION
Expand KBOX_LOW_FD_MAX from 1024 to 32768 so that
low_fds[] covers the entire range below KBOX_FD_BASE. Previously, dup2/dup3 targeting FDs in the gap returned EBADF because fd_lookup() returned NULL for that range.

This is Option A from issue #8: a simple constant change with ~1MB additional memory per instance.

Update unit tests to remove gap-expects-failure assertions and add coverage for FDs 1023, 10000, and 32767.

Resolves #8

Change-Id: I6c685c3ff473a9b393dbb3f373886abdaef5d7cd

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand `KBOX_LOW_FD_MAX` to 32768 to cover all FDs below `KBOX_FD_BASE` and close the low-FD gap. Fixes EBADF from `dup2`/`dup3` to FDs 1024-32767 (Option A in #8).

- **Bug Fixes**
  - `fd_lookup()` now maps 0-32767; ~1MB extra memory per instance.
  - Tests updated: removed gap-failure asserts; added cases for 1023, 10000, 32767.

<sup>Written for commit ab9036612220550ef228ae8e5856e05fe8be95dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

