### PR TITLE
Overhaul pre-commit hook and CI checks

### DIFF
--- a/.ci/check-cppcheck.sh
+++ b/.ci/check-cppcheck.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Run cppcheck static analysis on kbox source files (src/ only).
+# Tests are excluded -- they use stubs and have different rules.
+#
+# CI mode: --max-configs=1 + --enable=warning for speed.
+# Deep analysis runs in the pre-commit hook on individual changed files.
+
+set -e -u -o pipefail
+
+# Exclude syscall-nr.c: it's a data table that causes cppcheck to hang
+# on older versions (>100s). The pre-commit hook checks it per-file.
+mapfile -t SOURCES < <(git ls-files -z -- 'src/*.c' | tr '\0' '\n' | grep -v 'syscall-nr\.c')
+
+if [ ${#SOURCES[@]} -eq 0 ]; then
+    echo "No tracked C source files found."
+    exit 0
+fi
+
+# Run cppcheck with a timeout to prevent CI hangs.
+# 120s is generous -- this should finish in <30s with --max-configs=1.
+timeout 120 cppcheck \
+    -I. -Iinclude -Isrc \
+    --platform=unix64 \
+    --enable=warning \
+    --max-configs=1 --error-exitcode=1 --inline-suppr \
+    --suppress=checkersReport --suppress=unmatchedSuppression \
+    --suppress=missingIncludeSystem --suppress=noValidConfiguration \
+    --suppress=normalCheckLevelMaxBranches \
+    --suppress=preprocessorErrorDirective \
+    -D_GNU_SOURCE -D__linux__ \
+    "${SOURCES[@]}"

--- a/.ci/check-format.sh
+++ b/.ci/check-format.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Verify clang-format-20 conformance for all tracked C/H files.
+
+# Require clang-format-20 -- older versions produce different output.
+if [ -z "${CLANG_FORMAT:-}" ]; then
+    if command -v clang-format-20 >/dev/null 2>&1; then
+        CLANG_FORMAT="clang-format-20"
+    else
+        echo "Error: clang-format-20 is required (older versions differ in style)" >&2
+        exit 1
+    fi
+fi
+
+ret=0
+while IFS= read -r -d '' file; do
+    expected=$(mktemp)
+    "$CLANG_FORMAT" "$file" >"$expected" 2>/dev/null
+    if ! diff -u -p --label="$file" --label="expected coding style" "$file" "$expected"; then
+        ret=1
+    fi
+    rm -f "$expected"
+done < <(git ls-files -z -- '*.c' '*.h')
+
+exit $ret

--- a/.ci/check-newline.sh
+++ b/.ci/check-newline.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Ensure all tracked C/H files end with a newline.
+
+set -e -u -o pipefail
+
+ret=0
+while IFS= read -rd '' f; do
+    if file --mime-encoding "$f" | grep -qv binary; then
+        if [ -n "$(tail -c1 < "$f")" ]; then
+            echo "Warning: No newline at end of file $f"
+            ret=1
+        fi
+    fi
+done < <(git ls-files -z -- '*.c' '*.h')
+
+exit $ret

--- a/.ci/check-security.sh
+++ b/.ci/check-security.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Security checks for kbox source files (src/ and include/ only).
+# Tests and guest/stress binaries are excluded -- they have different rules.
+#
+# 1. Banned functions -- unsafe libc calls with safer alternatives.
+# 2. Credential / secret patterns -- catch accidental key leaks.
+# 3. Dangerous preprocessor -- detect disabled security features.
+
+set -u -o pipefail
+
+failed=0
+
+# --- Patterns ---
+banned='(^|[^[:alnum:]_])(gets|sprintf|vsprintf|strcpy|stpcpy|strcat|atoi|atol|atoll|atof|mktemp|tmpnam|tempnam)[[:space:]]*\('
+secrets='(password|secret|api_key|private_key|token)[[:space:]]*=[[:space:]]*"[^"]+'
+dangerous_pp='#[[:space:]]*(undef|define)[[:space:]]+((_FORTIFY_SOURCE[[:space:]]+0)|(__SSP__))'
+comment_only='^[[:space:]]*(//|/\*|\*|\*/)'
+
+# Only scan kbox source, not tests/guest/stress.
+while IFS= read -r -d '' f; do
+    # Skip comment-only matches before checking.
+    code=$(grep -vE "$comment_only" "$f")
+
+    if echo "$code" | grep -qE "$banned"; then
+        echo "Banned function in $f:"
+        grep -nE "$banned" "$f" | grep -vE "$comment_only"
+        failed=1
+    fi
+    if echo "$code" | grep -iqE "$secrets"; then
+        echo "Possible hardcoded secret in $f:"
+        grep -inE "$secrets" "$f" | grep -vE "$comment_only"
+        failed=1
+    fi
+    if echo "$code" | grep -qE "$dangerous_pp"; then
+        echo "Dangerous preprocessor directive in $f:"
+        grep -nE "$dangerous_pp" "$f" | grep -vE "$comment_only"
+        failed=1
+    fi
+done < <(git ls-files -z -- 'src/*.c' 'src/*.h' 'include/*.h' 'include/**/*.h')
+
+if [ $failed -eq 0 ]; then
+    echo "Security checks passed."
+fi
+
+exit $failed

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,14 +1,40 @@
-# Top-level EditorConfig file
 root = true
 
-# Shell script-specific settings
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[Makefile]
+indent_style = tab
+indent_size = 4
+
+[mk/*]
+indent_style = tab
+indent_size = 4
+
+[*.[ch]]
+indent_style = space
+indent_size = 4
+max_line_length = 80
+
+[*.py]
+indent_style = space
+indent_size = 4
+
 [*.sh]
 indent_style = space
 indent_size = 4
-end_of_line = lf
-trim_trailing_whitespace = true
-insert_final_newline = true
-function_next_line = true
-switch_case_indent = true
-space_redirects = true
-binary_next_line = true
+
+[*.hook]
+indent_style = space
+indent_size = 4
+
+[*.yml]
+indent_style = space
+indent_size = 2
+# test
+# test
+# test
+# test
+# x

--- a/.github/workflows/build-kbox.yml
+++ b/.github/workflows/build-kbox.yml
@@ -1,12 +1,15 @@
 # Build kbox and run full test suite.
 # Zero root required -- everything runs as an unprivileged user.
 #
-# Parallelism:
-#   unit-tests   -- no LKL, no rootfs, runs immediately
-#   build-kbox   -- fetches LKL, compiles kbox + guest/stress bins, builds rootfs
-#   integration  -- needs build-kbox artifacts, runs integration + stress tests
+# Parallelism (5 independent jobs, 1 sequential):
+#   coding-style     -- clang-format + newline checks (fast)
+#   static-analysis  -- security patterns + cppcheck
+#   unit-tests       -- no LKL dependency, ASAN/UBSAN
+#   build-kbox       -- fetches LKL, compiles kbox + guest/stress bins, builds rootfs
+#   integration      -- needs build-kbox artifacts, runs integration + stress tests
 #
-# unit-tests and build-kbox run in parallel. integration waits for build-kbox.
+# coding-style, static-analysis, unit-tests, and build-kbox run in parallel.
+# integration-tests waits for build-kbox only.
 name: Build and Test
 
 on:
@@ -16,6 +19,42 @@ on:
     branches: [main]
 
 jobs:
+  # ---- Coding style: formatting checks (fast, ~10s) ----
+  coding-style:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format-20
+
+      - name: Check trailing newline
+        run: .ci/check-newline.sh
+
+      - name: Check clang-format
+        run: .ci/check-format.sh
+
+  # ---- Static analysis: security patterns + cppcheck ----
+  static-analysis:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install cppcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cppcheck
+
+      - name: Security checks
+        run: .ci/check-security.sh
+
+      - name: Static analysis (cppcheck)
+        run: .ci/check-cppcheck.sh
+
   # ---- Unit tests: no LKL dependency, fast ----
   unit-tests:
     runs-on: ubuntu-24.04

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ KCONFIG_CONF := configs/Kconfig
 
 # Targets that don't require .config
 CONFIG_TARGETS    := config defconfig oldconfig savedefconfig clean distclean indent \
-                     check-unit fetch-lkl build-lkl fetch-minislirp install-hooks \
-                     guest-bins stress-bins rootfs
+                     check-unit check-syntax fetch-lkl build-lkl fetch-minislirp \
+                     install-hooks guest-bins stress-bins rootfs
 CONFIG_GENERATORS := config defconfig oldconfig
 
 # Require .config for build targets.

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -6,6 +6,7 @@ TEST_DIR   = tests/unit
 TEST_SRCS  = $(TEST_DIR)/test-runner.c \
              $(TEST_DIR)/test-fd-table.c \
              $(TEST_DIR)/test-path.c \
+             $(TEST_DIR)/test-cli.c \
              $(TEST_DIR)/test-identity.c \
              $(TEST_DIR)/test-syscall-nr.c \
              $(TEST_DIR)/test-elf.c \
@@ -29,6 +30,7 @@ endif
 # Unit tests link only the pure-computation sources (no LKL)
 TEST_SUPPORT_SRCS = $(SRC_DIR)/fd-table.c \
                     $(SRC_DIR)/path.c \
+                    $(SRC_DIR)/cli.c \
                     $(SRC_DIR)/identity.c \
                     $(SRC_DIR)/syscall-nr.c \
                     $(SRC_DIR)/elf.c \
@@ -111,4 +113,45 @@ $(ROOTFS): scripts/mkrootfs.sh scripts/alpine-sha256.txt $(GUEST_BINS) $(STRESS_
 	@echo "  GEN     $@"
 	$(Q)ALPINE_ARCH=$(ARCH) ./scripts/mkrootfs.sh
 
-.PHONY: check check-unit check-integration check-stress guest-bins stress-bins rootfs
+# ---- Syntax-only compilation check (used by pre-commit hook) ----
+# Usage: make check-syntax CHK_SOURCES="src/foo.c src/bar.c"
+# Uses the project's real CFLAGS with -fsyntax-only (no linking, no .o output).
+# Skips gracefully on non-Linux compilers.
+
+CHK_CC_TARGET := $(shell $(CC) -dumpmachine 2>/dev/null)
+check-syntax:
+ifeq ($(findstring linux,$(CHK_CC_TARGET)),)
+	@echo "  SKIP    check-syntax (non-Linux compiler: $(CHK_CC_TARGET))"
+else
+ifdef CHK_SOURCES
+	@echo "  SYNTAX  $(words $(CHK_SOURCES)) file(s)"
+	$(Q)$(CC) $(CFLAGS) -DKBOX_UNIT_TEST -fsyntax-only \
+	    -Werror=implicit-function-declaration \
+	    -Werror=incompatible-pointer-types \
+	    -Werror=int-conversion \
+	    -Werror=return-type \
+	    -Werror=format=2 \
+	    -Werror=format-security \
+	    -Werror=strict-prototypes \
+	    -Werror=old-style-definition \
+	    -Werror=sizeof-pointer-memaccess \
+	    -Werror=vla \
+	    $(CHK_SOURCES)
+else
+	@echo "  SYNTAX  all source files"
+	$(Q)$(CC) $(CFLAGS) -DKBOX_UNIT_TEST -fsyntax-only \
+	    -Werror=implicit-function-declaration \
+	    -Werror=incompatible-pointer-types \
+	    -Werror=int-conversion \
+	    -Werror=return-type \
+	    -Werror=format=2 \
+	    -Werror=format-security \
+	    -Werror=strict-prototypes \
+	    -Werror=old-style-definition \
+	    -Werror=sizeof-pointer-memaccess \
+	    -Werror=vla \
+	    $(SRCS)
+endif
+endif
+
+.PHONY: check check-unit check-integration check-stress guest-bins stress-bins rootfs check-syntax

--- a/scripts/build-lkl.sh
+++ b/scripts/build-lkl.sh
@@ -12,7 +12,7 @@
 set -eu
 
 case "${1:-$(uname -m)}" in
-    x86_64 | amd64)  ARCH="x86_64"  ;;
+    x86_64 | amd64) ARCH="x86_64" ;;
     aarch64 | arm64) ARCH="aarch64" ;;
     *)
         echo "error: unsupported architecture: ${1:-$(uname -m)}" >&2
@@ -24,7 +24,11 @@ LKL_DIR="${LKL_DIR:-lkl-${ARCH}}"
 LKL_SRC="${LKL_SRC:-build/lkl-src}"
 LKL_UPSTREAM="https://github.com/lkl/linux"
 
-die() { echo "error: $*" >&2; exit 1; }
+die()
+{
+    echo "error: $*" >&2
+    exit 1
+}
 
 # ---- Clone or update source tree ----------------------------------------
 
@@ -66,8 +70,7 @@ for opt in \
     CONFIG_PRINTK \
     CONFIG_TRACEPOINTS \
     CONFIG_FTRACE \
-    CONFIG_DEBUG_FS \
-; do
+    CONFIG_DEBUG_FS; do
     "${LKL_SRC}/scripts/config" --file "${LKL_SRC}/.config" --enable "${opt}"
 done
 
@@ -80,8 +83,7 @@ for opt in \
     CONFIG_USB_SUPPORT \
     CONFIG_INPUT \
     CONFIG_NFS_FS \
-    CONFIG_CIFS \
-; do
+    CONFIG_CIFS; do
     "${LKL_SRC}/scripts/config" --file "${LKL_SRC}/.config" --disable "${opt}"
 done
 
@@ -89,7 +91,7 @@ make -C "${LKL_SRC}" ARCH=lkl olddefconfig
 
 # ---- Build ---------------------------------------------------------------
 
-NPROC=$(nproc 2>/dev/null || echo 1)
+NPROC=$(nproc 2> /dev/null || echo 1)
 
 echo "  BUILD   ARCH=lkl kernel (-j${NPROC})"
 make -C "${LKL_SRC}" ARCH=lkl -j"${NPROC}"
@@ -104,10 +106,10 @@ test -f "${LKL_SRC}/tools/lkl/liblkl.a" \
 
 echo "  VERIFY  symbols"
 for sym in lkl_init lkl_start_kernel lkl_cleanup lkl_syscall \
-           lkl_strerror lkl_disk_add lkl_mount_dev \
-           lkl_host_ops lkl_dev_blk_ops; do
-    if ! nm "${LKL_SRC}/tools/lkl/liblkl.a" 2>/dev/null \
-         | awk -v s="$sym" '$3==s && $2~/^[TtDdBbRr]$/{found=1} END{exit !found}'; then
+    lkl_strerror lkl_disk_add lkl_mount_dev \
+    lkl_host_ops lkl_dev_blk_ops; do
+    if ! nm "${LKL_SRC}/tools/lkl/liblkl.a" 2> /dev/null \
+        | awk -v s="$sym" '$3==s && $2~/^[TtDdBbRr]$/{found=1} END{exit !found}'; then
         die "MISSING symbol: ${sym}"
     fi
 done
@@ -117,10 +119,10 @@ done
 echo "  INSTALL ${LKL_DIR}/"
 mkdir -p "${LKL_DIR}"
 
-cp "${LKL_SRC}/tools/lkl/liblkl.a"               "${LKL_DIR}/"
-cp "${LKL_SRC}/tools/lkl/include/lkl.h"          "${LKL_DIR}/" 2>/dev/null || true
-cp "${LKL_SRC}/tools/lkl/include/lkl/autoconf.h" "${LKL_DIR}/" 2>/dev/null || true
-cp "${LKL_SRC}/scripts/gdb/vmlinux-gdb.py"        "${LKL_DIR}/" 2>/dev/null || true
+cp "${LKL_SRC}/tools/lkl/liblkl.a" "${LKL_DIR}/"
+cp "${LKL_SRC}/tools/lkl/include/lkl.h" "${LKL_DIR}/" 2> /dev/null || true
+cp "${LKL_SRC}/tools/lkl/include/lkl/autoconf.h" "${LKL_DIR}/" 2> /dev/null || true
+cp "${LKL_SRC}/scripts/gdb/vmlinux-gdb.py" "${LKL_DIR}/" 2> /dev/null || true
 
 printf 'commit=%s\ndate=%s\narch=%s\n' \
     "$(git -C "${LKL_SRC}" rev-parse HEAD)" \
@@ -128,6 +130,6 @@ printf 'commit=%s\ndate=%s\narch=%s\n' \
     "${ARCH}" \
     > "${LKL_DIR}/BUILD_INFO"
 
-( cd "${LKL_DIR}" && sha256sum ./* > sha256sums.txt )
+(cd "${LKL_DIR}" && sha256sum ./* > sha256sums.txt)
 
 echo "OK: ${LKL_DIR}/liblkl.a"

--- a/scripts/commit-msg.hook
+++ b/scripts/commit-msg.hook
@@ -3,11 +3,23 @@
 # commit-msg hook for kbox: validate message format and append Change-Id.
 # Adapted from git-good-commit (MIT License) via lab0-c.
 
+resolve_script_dir() {
+    local source="${BASH_SOURCE[0]}"
+    while [ -L "$source" ]; do
+        local dir
+        dir=$(cd -P "$(dirname "$source")" && pwd) || return 1
+        source=$(readlink "$source") || return 1
+        [[ $source != /* ]] && source="$dir/$source"
+    done
+    cd -P "$(dirname "$source")" && pwd
+}
+
 COMMIT_MSG_FILE="$1"
 
 # Source common.sh for color support (optional -- degrades gracefully).
-common_script="$(dirname "$0")/../../scripts/common.sh"
-[ -r "$common_script" ] && source "$common_script" && set_colors 2> /dev/null
+script_dir=$(resolve_script_dir) || script_dir=""
+common_script="$script_dir/common.sh"
+[ -r "$common_script" ] && source "$common_script" && set_colors 2>/dev/null
 RED="${RED:-}" GREEN="${GREEN:-}" YELLOW="${YELLOW:-}" CYAN="${CYAN:-}" NC="${NC:-}"
 
 WARNINGS=()
@@ -29,7 +41,7 @@ while IFS= read -r line; do
     # Skip comment lines.
     [[ $line =~ ^# ]] && continue
     COMMIT_MSG_LINES+=("$line")
-done < "$COMMIT_MSG_FILE"
+done <"$COMMIT_MSG_FILE"
 
 # Strip trailing blank lines.
 while [ ${#COMMIT_MSG_LINES[@]} -gt 0 ] && [ -z "${COMMIT_MSG_LINES[-1]}" ]; do
@@ -166,12 +178,12 @@ else
 
     # 11. Reject placeholder/padding text (runs of 4+ identical alphabetic characters).
     padding_char=$(printf '%s' "$SUBJECT" | awk '{
-	prev = ""; run = 0
-	for (i = 1; i <= length($0); i++) {
-		c = substr($0, i, 1)
-		if (c == prev) { run++ } else { run = 1; prev = c }
-		if (run >= 4 && c ~ /[A-Za-z]/) { printf "%s", c; exit }
-	}
+    prev = ""; run = 0
+    for (i = 1; i <= length($0); i++) {
+        c = substr($0, i, 1)
+        if (c == prev) { run++ } else { run = 1; prev = c }
+        if (run >= 4 && c ~ /[A-Za-z]/) { printf "%s", c; exit }
+    }
 }')
     if [ -n "$padding_char" ]; then
         add_error "Subject contains repeated padding '${padding_char}${padding_char}${padding_char}${padding_char}...' (placeholder text?)"
@@ -216,7 +228,7 @@ clean_message=$(sed -e '/^#/d' -e '/^diff --git /{ s///; q; }' \
 _gen_changeid_input() {
     echo "tree $(git write-tree)"
     local parent
-    if parent=$(git rev-parse "HEAD^0" 2> /dev/null); then
+    if parent=$(git rev-parse "HEAD^0" 2>/dev/null); then
         echo "parent $parent"
     fi
     echo "author $(git var GIT_AUTHOR_IDENT)"
@@ -232,7 +244,7 @@ commentChar=$(git config --get core.commentChar || echo '#')
 
 awk -v id="$change_id" -v cc="$commentChar" '
 BEGIN {
-	isFooter = 0; footerComment = 0; blankLines = 0
+    isFooter = 0; footerComment = 0; blankLines = 0
 }
 index($0, cc) == 1 { next }
 /^diff --git / { blankLines = 0; while (getline) {}; next }
@@ -240,35 +252,35 @@ index($0, cc) == 1 { next }
 /^\[[a-zA-Z0-9-]+:/ && (isFooter == 1) { footerComment = 1 }
 /]$/ && (footerComment == 1) { footerComment = 2 }
 (blankLines > 0) {
-	print lines
-	for (i = 0; i < blankLines; i++) print ""
-	lines = ""; blankLines = 0; isFooter = 1; footerComment = 0
+    print lines
+    for (i = 0; i < blankLines; i++) print ""
+    lines = ""; blankLines = 0; isFooter = 1; footerComment = 0
 }
 (footerComment == 0) && (!/^\[?[a-zA-Z0-9-]+:/ || /^[a-zA-Z0-9-]+:\/\//) {
-	isFooter = 0
+    isFooter = 0
 }
 {
-	if (footerComment == 2) footerComment = 0
-	if (lines != "") lines = lines "\n"
-	lines = lines $0
+    if (footerComment == 2) footerComment = 0
+    if (lines != "") lines = lines "\n"
+    lines = lines $0
 }
 END {
-	unprinted = 1
-	if (isFooter == 0) { print lines "\n"; lines = "" }
-	# Split footer, place Change-Id after other trailers but before *-by lines.
-	numlines = split(lines, footer, "\n")
-	trailers = ""; other = ""
-	for (i = 1; i <= numlines; i++) {
-		low = tolower(footer[i])
-		if (low ~ /^(signed-off|reviewed|co-authored|acked|suggested|tested|reported)-by:/) {
-			trailers = trailers footer[i] "\n"
-		} else {
-			other = other footer[i] "\n"
-		}
-	}
-	if (other != "") printf "%s", other
-	if (trailers != "") printf "%s", trailers
-	printf "Change-Id: I%s\n", id
-}' "$COMMIT_MSG_FILE" > "${COMMIT_MSG_FILE}.tmp" \
-    && mv "${COMMIT_MSG_FILE}.tmp" "$COMMIT_MSG_FILE" \
-    || rm -f "${COMMIT_MSG_FILE}.tmp"
+    unprinted = 1
+    if (isFooter == 0) { print lines "\n"; lines = "" }
+    # Split footer, place Change-Id after other trailers but before *-by lines.
+    numlines = split(lines, footer, "\n")
+    trailers = ""; other = ""
+    for (i = 1; i <= numlines; i++) {
+        low = tolower(footer[i])
+        if (low ~ /^(signed-off|reviewed|co-authored|acked|suggested|tested|reported)-by:/) {
+            trailers = trailers footer[i] "\n"
+        } else {
+            other = other footer[i] "\n"
+        }
+    }
+    if (other != "") printf "%s", other
+    if (trailers != "") printf "%s", trailers
+    printf "Change-Id: I%s\n", id
+}' "$COMMIT_MSG_FILE" >"${COMMIT_MSG_FILE}.tmp" &&
+    mv "${COMMIT_MSG_FILE}.tmp" "$COMMIT_MSG_FILE" ||
+    rm -f "${COMMIT_MSG_FILE}.tmp"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -3,17 +3,40 @@
 
 set_colors()
 {
-    if [ -t 1 ] && command -v tput > /dev/null 2>&1 && [ "$(tput colors 2> /dev/null)" -ge 8 ] 2> /dev/null; then
-        RED='\033[0;31m'
-        GREEN='\033[0;32m'
-        YELLOW='\033[0;33m'
-        CYAN='\033[0;36m'
+    local default_color
+    default_color=$(git config --get color.ui 2> /dev/null || echo 'auto')
+    if [[ "$default_color" == "always" ]] || [[ "$default_color" == "auto" && -t 1 ]]; then
+        RED='\033[1;31m'
+        GREEN='\033[1;32m'
+        YELLOW='\033[1;33m'
+        BLUE='\033[1;34m'
+        WHITE='\033[1;37m'
+        CYAN='\033[1;36m'
         NC='\033[0m'
     else
         RED=''
         GREEN=''
         YELLOW=''
+        BLUE=''
+        WHITE=''
         CYAN=''
         NC=''
+    fi
+}
+
+# Print a fatal error message and exit.
+throw()
+{
+    local fmt="$1"
+    shift
+    printf "\n${RED}[!] $fmt${NC}\n" "$@" >&2
+    exit 1
+}
+
+# Skip hooks entirely when running in CI (GitHub Actions, etc.).
+check_ci()
+{
+    if [ -n "${CI:-}" ] || [ -d "/home/runner/work" ]; then
+        exit 0
     fi
 }

--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -1,35 +1,50 @@
 #!/usr/bin/env bash
 
-# Pre-commit hook for kbox: formatting, static analysis, unsafe functions.
+# Pre-commit hook for kbox: code quality, security, and static analysis.
 
-common_script="$(dirname "$0")/../../scripts/common.sh"
+resolve_script_dir() {
+    local source="${BASH_SOURCE[0]}"
+    while [ -L "$source" ]; do
+        local dir
+        dir=$(cd -P "$(dirname "$source")" && pwd) || return 1
+        source=$(readlink "$source") || return 1
+        [[ $source != /* ]] && source="$dir/$source"
+    done
+    cd -P "$(dirname "$source")" && pwd
+}
+
+script_dir=$(resolve_script_dir) || {
+    echo "[!] failed to resolve hook path." >&2
+    exit 1
+}
+common_script="$script_dir/common.sh"
 [ -r "$common_script" ] || {
     echo "[!] '$common_script' not found or not readable." >&2
     exit 1
 }
-bash -n "$common_script" > /dev/null 2>&1 || {
+bash -n "$common_script" >/dev/null 2>&1 || {
     echo "[!] '$common_script' contains syntax errors." >&2
     exit 1
 }
 source "$common_script"
-declare -F set_colors > /dev/null 2>&1 || {
+declare -F set_colors >/dev/null 2>&1 || {
     echo "[!] '$common_script' does not define the required function." >&2
     exit 1
 }
 
 set_colors
+check_ci
 
 RETURN=0
 ERRORS_FOUND=()
 WARNINGS_FOUND=()
 
-TOTAL_CHECKS=7
 CURRENT_CHECK=0
 
 update_progress() {
     local check_name="$1"
     ((CURRENT_CHECK++))
-    printf "\r${CYAN}[%d/%d]${NC} %s..." "$CURRENT_CHECK" "$TOTAL_CHECKS" "$check_name"
+    printf "\r${CYAN}[%d]${NC} %s..." "$CURRENT_CHECK" "$check_name"
 }
 
 report_result() {
@@ -45,16 +60,108 @@ report_result() {
     fi
 }
 
-# Build cppcheck suppressions for kbox sources.
-cppcheck_suppressions() {
+report_warning() {
+    local message="$1"
+    printf " [ ${YELLOW}WARN${NC} ]\n"
+    if [ -n "$message" ]; then
+        WARNINGS_FOUND+=("$message")
+    fi
+}
+
+is_reported() {
+    local haystack="$1"
+    local needle="$2"
+    case "$haystack" in
+    *"|$needle|"*) return 0 ;;
+    *) return 1 ;;
+    esac
+}
+
+mark_reported() {
+    local haystack="$1"
+    local needle="$2"
+    printf '%s|%s|' "$haystack" "$needle"
+}
+
+strip_strings_and_comments() {
+    local line="$1"
+    local in_block_comment="$2"
+    local out=""
+    local i=0
+    local len=${#line}
+    local ch next quote
+
+    while [ $i -lt $len ]; do
+        ch="${line:$i:1}"
+        if [ "$in_block_comment" = "1" ]; then
+            if [ "$ch" = "*" ] && [ $((i + 1)) -lt $len ] && [ "${line:$((i + 1)):1}" = "/" ]; then
+                in_block_comment=0
+                i=$((i + 2))
+            else
+                i=$((i + 1))
+            fi
+            continue
+        fi
+
+        if [ "$ch" = "/" ] && [ $((i + 1)) -lt $len ]; then
+            next="${line:$((i + 1)):1}"
+            if [ "$next" = "/" ]; then
+                break
+            fi
+            if [ "$next" = "*" ]; then
+                in_block_comment=1
+                i=$((i + 2))
+                continue
+            fi
+        fi
+
+        if [ "$ch" = "\"" ] || [ "$ch" = "'" ]; then
+            quote="$ch"
+            out+=" "
+            i=$((i + 1))
+            while [ $i -lt $len ]; do
+                ch="${line:$i:1}"
+                if [ "$ch" = "\\" ] && [ $((i + 1)) -lt $len ]; then
+                    i=$((i + 2))
+                    continue
+                fi
+                if [ "$ch" = "$quote" ]; then
+                    i=$((i + 1))
+                    break
+                fi
+                i=$((i + 1))
+            done
+            continue
+        fi
+
+        out+="$ch"
+        i=$((i + 1))
+    done
+
+    printf '%s\n%s\n' "$in_block_comment" "$out"
+}
+
+# Single temp directory for the entire run; cleaned up on exit or signal.
+HOOK_TMPDIR=$(mktemp -d) || exit 1
+cleanup() {
+    rm -rf "$HOOK_TMPDIR" 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+# Build cppcheck suppressions (cached -- called once).
+# Only suppress diagnostics that are genuinely unhelpful. Removed:
+#   syntaxError, noValidConfiguration -- mask total analysis failure
+#   compareValueOutOfTypeRangeError -- catches real truncation bugs
+#   knownConditionTrueFalse -- reveals dead code / logic errors
+#   shadowVariable -- catches wrong-variable bugs in large functions
+#   unreadVariable, redundantInitialization -- reveals forgotten checks
+build_cppcheck_suppressions() {
     local -a suppr_keys=(
         "checkersReport"
         "unmatchedSuppression"
         "normalCheckLevelMaxBranches"
         "missingIncludeSystem"
-        "noValidConfiguration"
         "unusedFunction"
-        "syntaxError"
         "constParameterPointer"
         "constParameterCallback"
         "constVariablePointer"
@@ -64,31 +171,33 @@ cppcheck_suppressions() {
         "staticFunction"
         "checkLevelNormal"
         "variableScope"
-        "compareValueOutOfTypeRangeError"
         "constVariable"
-        "knownConditionTrueFalse"
-        "unreadVariable"
-        "redundantInitialization"
-        "shadowVariable"
         "preprocessorErrorDirective"
+        "invalidFunctionArg:src/elf.c"
+        "invalidFunctionArg:src/loader-image.c"
+        "invalidFunctionArg:src/loader-launch.c"
+        "invalidFunctionArg:src/loader-stack.c"
+        "memleak:src/loader-stack.c"
     )
 
     local out="--inline-suppr "
     for key in "${suppr_keys[@]}"; do
         out+="--suppress=$key "
     done
-    printf "%s" "$out" | sed 's/[[:space:]]*$//'
+    printf "%s" "${out% }"
 }
 
-# Detect compiler standard defines for cppcheck.
-detect_cc_std() {
+# Detect compiler standard defines (cached -- called once).
+build_cc_std_defines() {
     local STDC_VERSION=""
     local EXTRA_DEFINES=""
-    if command -v cc > /dev/null 2>&1; then
-        if cc --version 2> /dev/null | grep -q "clang"; then
+    if command -v cc >/dev/null 2>&1; then
+        local cc_ver
+        cc_ver=$(cc --version 2>/dev/null)
+        if echo "$cc_ver" | grep -q "clang"; then
             STDC_VERSION=$(cc -dM -E -xc /dev/null | awk '/__STDC_VERSION__/ {print $3}')
             EXTRA_DEFINES="-D__clang__=1"
-        elif cc --version 2> /dev/null | grep -q "Free Software Foundation"; then
+        elif echo "$cc_ver" | grep -q "Free Software Foundation"; then
             STDC_VERSION=$(cc -dM -E -xc /dev/null | awk '/__STDC_VERSION__/ {print $3}')
             EXTRA_DEFINES="-D__GNUC__=1"
         fi
@@ -99,32 +208,34 @@ detect_cc_std() {
     echo "$EXTRA_DEFINES"
 }
 
-# Resolve clang-format: prefer clang-format-20, fall back to Homebrew LLVM 20.
-CLANG_FORMAT=""
-for cf in clang-format-20 /opt/homebrew/Cellar/llvm@20/*/bin/clang-format; do
-    if command -v "$cf" > /dev/null 2>&1 || [ -x "$cf" ]; then
-        CLANG_FORMAT="$cf"
-        break
+# Resolve clang-format-20: try versioned binary, then unversioned if it's v20.
+resolve_clang_format() {
+    if command -v clang-format-20 >/dev/null 2>&1; then
+        echo "clang-format-20"
+        return
     fi
-done
-[ -z "$CLANG_FORMAT" ] && CLANG_FORMAT="clang-format"
+    if command -v clang-format >/dev/null 2>&1; then
+        if clang-format --version 2>/dev/null | grep -q 'version 20'; then
+            echo "clang-format"
+            return
+        fi
+    fi
+    echo ""
+}
 
-# Check for required tools
+CLANG_FORMAT=$(resolve_clang_format)
+
+# Check for required tools.
 check_required_tools() {
+    local need_c_tools="$1"
     local missing_tools=()
 
-    if ! command -v "$CLANG_FORMAT" > /dev/null 2>&1 && [ ! -x "$CLANG_FORMAT" ]; then
+    if [ "$need_c_tools" -eq 1 ] && [ -z "$CLANG_FORMAT" ]; then
         missing_tools+=("clang-format-20")
     fi
 
-    if ! command -v cppcheck > /dev/null 2>&1; then
+    if [ "$need_c_tools" -eq 1 ] && ! command -v cppcheck >/dev/null 2>&1; then
         missing_tools+=("cppcheck")
-    fi
-
-    if ! command -v aspell > /dev/null 2>&1; then
-        missing_tools+=("aspell")
-    elif [ -z "$(aspell dump dicts 2> /dev/null | grep -E '^en$')" ]; then
-        missing_tools+=("aspell-en")
     fi
 
     if [ ${#missing_tools[@]} -gt 0 ]; then
@@ -138,126 +249,423 @@ check_required_tools() {
 }
 
 printf "${CYAN}Running pre-commit checks...${NC}\n\n"
-check_required_tools
-
-CPPCHECK_OPTS="-I. -Iinclude -Isrc --enable=all --error-exitcode=1"
-CPPCHECK_OPTS+=" $(detect_cc_std)"
-CPPCHECK_OPTS+=" --max-configs=4 $(cppcheck_suppressions)"
-CPPCHECK_OPTS+=" -D_GNU_SOURCE -DKBOX_UNIT_TEST"
 
 workspace=$(git rev-parse --show-toplevel)
 
-mapfile -t FILES < <(git diff --cached --name-only --diff-filter=ACM)
+# Gather all staged info in as few git calls as possible.
+# --no-renames: treats renames as delete+add (avoids "old => new" path corruption).
+# -z: NUL-terminated output. Format: "add\tdel\tpath\0" per entry.
+FILES=()
+FILE_SUMMARIES=()
+binary_files=()
+while IFS= read -r -d '' record; do
+    [ -z "$record" ] && continue
+    add="${record%%	*}"; rest="${record#*	}"
+    del="${rest%%	*}"; path="${rest#*	}"
+    FILES+=("$path")
+    if [ "$add" = "-" ] && [ "$del" = "-" ]; then
+        binary_files+=("$path")
+        FILE_SUMMARIES+=("(binary)")
+    elif [ "$add" != "0" ] && [ "$del" != "0" ]; then
+        FILE_SUMMARIES+=("+${add}/-${del}")
+    elif [ "$add" != "0" ]; then
+        FILE_SUMMARIES+=("+${add}")
+    elif [ "$del" != "0" ]; then
+        FILE_SUMMARIES+=("-${del}")
+    else
+        FILE_SUMMARIES+=("")
+    fi
+done < <(git diff --cached --numstat --no-renames --diff-filter=ACM -z 2>/dev/null)
 
 if [ ${#FILES[@]} -eq 0 ]; then
     printf "${YELLOW}No files staged for commit.${NC}\n"
     exit 0
 fi
 
+# Determine which C/H files actually changed vs HEAD (single git command).
+# On amend, most staged files are unchanged re-commits -- skip them entirely.
+# On initial commit (no HEAD), fall back to all staged files.
+C_FILES_CHANGED=()
+if git rev-parse --verify HEAD >/dev/null 2>&1; then
+    while IFS= read -r -d '' f; do
+        [[ $f == *.c || $f == *.h ]] && C_FILES_CHANGED+=("$f")
+    done < <(git diff --cached --name-only --no-renames --diff-filter=ACM HEAD -z 2>/dev/null)
+else
+    # Initial commit: all staged C/H files are new.
+    for f in "${FILES[@]}"; do
+        [[ $f == *.c || $f == *.h ]] && C_FILES_CHANGED+=("$f")
+    done
+fi
+
+check_required_tools $(( ${#C_FILES_CHANGED[@]} > 0 ))
+
+# Materialize staged content only if C/H files actually changed.
+STAGED_DIR="$HOOK_TMPDIR/staged"
+DIFF_CACHE="$HOOK_TMPDIR/diff_cache"
+CACHED_CC_STD=""
+CACHED_SUPPRESSIONS=""
+if [ ${#C_FILES_CHANGED[@]} -gt 0 ]; then
+    mkdir -p "$STAGED_DIR"
+
+    # Batch-extract changed C/H files + all tracked headers in one call.
+    {
+        printf '%s\0' "${C_FILES_CHANGED[@]}"
+        git ls-files -z -- '*.h' 'include/*.h' 'include/**/*.h' 'src/*.h'
+    } | git checkout-index --stdin -z -f --prefix="$STAGED_DIR/" 2>/dev/null
+
+    # Preserve the active configuration so feature-gated code is syntax-checked
+    # with the same options the real build uses.
+    [ -f .config ] && cp .config "$STAGED_DIR/.config"
+
+    git diff --cached -U0 -- "${C_FILES_CHANGED[@]}" >"$DIFF_CACHE" 2>/dev/null
+
+    CACHED_CC_STD=$(build_cc_std_defines)
+    CACHED_SUPPRESSIONS=$(build_cppcheck_suppressions)
+fi
+
 # === CHECK 1: Workspace path validation ===
 update_progress "Checking workspace path"
-if echo "$workspace" | LC_ALL=C grep -q "[一-龥]"; then
+if echo "$workspace" | LC_ALL=C grep -q '[^ -~]'; then
     report_result 1 "Workspace path contains non-ASCII characters"
     RETURN=1
 else
     report_result 0
 fi
 
-# === CHECK 2: Merge conflict markers ===
+# === CHECK 2: Merge conflict markers (single git grep) ===
 update_progress "Checking for merge conflicts"
-CONFLICT_MARKERS=$(printf '%s|%s|%s' "<<<<<<<" "=======" ">>>>>>>")
-CONFLICT_FILES=$(git diff --cached --name-only -G "${CONFLICT_MARKERS}" \
-    | grep -vE '(^|/)\.git/hooks/|(^|/)(pre-commit|commit-msg|prepare-commit-msg|pre-push)\.hook$')
+CONFLICT_FILES=$(git grep --cached -lE '^(<{7}|={7}|>{7})( |$)' -- "${FILES[@]}" 2>/dev/null |
+    grep -vE '(^|/)(pre-commit|commit-msg|prepare-commit-msg|pre-push)\.hook$' || true)
 if [ -n "${CONFLICT_FILES}" ]; then
-    report_result 1 "Conflict markers found in: ${CONFLICT_FILES}"
+    report_result 1 "Conflict markers found in: $(echo "$CONFLICT_FILES" | tr '\n' ' ')"
     RETURN=1
 else
     report_result 0
 fi
 
-# === CHECK 3: Binary files ===
+# === CHECK 3: Binary files (warning only, parsed from initial numstat) ===
 update_progress "Checking for binary files"
-binary_files=()
-for file in "${FILES[@]}"; do
-    if [ -f "$file" ]; then
-        mime_info=$(file --mime "$file" 2> /dev/null)
-        if echo "$mime_info" | grep -qi binary; then
-            binary_files+=("$file")
-        fi
-    fi
-done
 if [ ${#binary_files[@]} -gt 0 ]; then
-    report_result 1 "Binary files detected: ${binary_files[*]}"
-    WARNINGS_FOUND+=("Binary files should not be committed")
+    report_warning "Binary files detected: ${binary_files[*]}"
 else
     report_result 0
 fi
 
-# === CHECK 4: Code formatting ===
+# === CHECK 4: Whitespace errors ===
+update_progress "Checking for whitespace errors"
+ws_errors=$(git diff --cached --check 2>&1 || true)
+if [ -n "$ws_errors" ]; then
+    ws_count=$(echo "$ws_errors" | wc -l)
+    report_result 1 "Whitespace errors in $ws_count location(s)"
+    RETURN=1
+else
+    report_result 0
+fi
+
+# === CHECK 5: Code formatting (clang-format-20) ===
 update_progress "Checking code formatting"
-mapfile -t C_FILES < <(git diff --cached --name-only --diff-filter=ACMR | grep -E "\.(c|h)$" || true)
 formatting_errors=0
-if [ ${#C_FILES[@]} -gt 0 ]; then
-    for FILE in "${C_FILES[@]}"; do
-        if [ -f "$FILE" ]; then
-            nf=$(git checkout-index --temp "$FILE" | cut -f 1)
-            tempdir=$(mktemp -d) || exit 1
-            newfile=$(mktemp "${tempdir}/${nf}.XXXXXX") || exit 1
-            basename=$(basename "$FILE")
-
-            source="${tempdir}/${basename}"
-            mv "$nf" "$source"
-            cp .clang-format "$tempdir" 2> /dev/null || true
-            "$CLANG_FORMAT" "$source" > "$newfile" 2> /dev/null
-
-            if ! diff -q "${source}" "${newfile}" > /dev/null 2>&1; then
+formatting_files=()
+if [ ${#C_FILES_CHANGED[@]} -gt 0 ]; then
+    cp .clang-format "$STAGED_DIR" 2>/dev/null || true
+    for FILE in "${C_FILES_CHANGED[@]}"; do
+        staged_file="$STAGED_DIR/$FILE"
+        if [ -f "$staged_file" ]; then
+            formatted="$HOOK_TMPDIR/fmt_${FILE//\//_}"
+            "$CLANG_FORMAT" "$staged_file" >"$formatted" 2>/dev/null
+            if ! diff -q "$staged_file" "$formatted" >/dev/null 2>&1; then
                 formatting_errors=$((formatting_errors + 1))
-                WARNINGS_FOUND+=("$FILE needs formatting (run: clang-format -i $FILE)")
+                formatting_files+=("$FILE")
             fi
-            rm -rf "${tempdir}"
         fi
     done
 fi
 if [ $formatting_errors -gt 0 ]; then
     report_result 1 "$formatting_errors file(s) need formatting"
+    for ff in "${formatting_files[@]}"; do
+        WARNINGS_FOUND+=("  run: $CLANG_FORMAT -i $ff")
+    done
     RETURN=1
 else
     report_result 0
 fi
 
-# === CHECK 5: Unsafe functions ===
-update_progress "Checking for unsafe functions"
+# === CHECK 6: Banned functions (newly added code only) ===
+update_progress "Checking for banned functions"
 unsafe_found=0
-if [ ${#C_FILES[@]} -gt 0 ]; then
-    banned="([^f]gets\()|(sprintf\()|(strcpy\()"
-    for file in "${C_FILES[@]}"; do
-        if [ -f "$file" ]; then
-            filepath="${workspace}/${file}"
-            if grep -qE "${banned}" "${filepath}" 2> /dev/null; then
-                unsafe_found=$((unsafe_found + 1))
-                line_nums=$(grep -nE "${banned}" "${filepath}" | cut -d: -f1 | tr '\n' ',' | sed 's/,$//')
-                ERRORS_FOUND+=("Unsafe functions in $file (lines: $line_nums)")
+# gets/sprintf/strcpy/strcat -- buffer overflow
+# atoi/atol/atoll/atof -- no error detection (use strtol/strtod)
+# mktemp/tmpnam/tempnam -- predictable name (use mkstemp)
+# vsprintf/stpcpy -- same risks as sprintf/strcpy
+banned='(^|[^[:alnum:]_])(gets|sprintf|vsprintf|strcpy|stpcpy|strcat|atoi|atol|atoll|atof|mktemp|tmpnam|tempnam)[[:space:]]*\('
+if [ ${#C_FILES_CHANGED[@]} -gt 0 ] && [ -s "$DIFF_CACHE" ]; then
+    current_file=""
+    banned_reported=""
+    in_block_comment=0
+    while IFS= read -r line; do
+        if [[ $line == "+++ b/"* ]]; then
+            current_file="${line#'+++ b/'}"
+            in_block_comment=0
+        elif [[ $line == "@@"* ]]; then
+            hunk_meta=${line#*+}
+            hunk_meta=${hunk_meta%% @@*}
+            hunk_start=${hunk_meta%%,*}
+            case "$hunk_start" in
+            ''|*[!0-9]*) current_line=0 ;;
+            *) current_line=$hunk_start ;;
+            esac
+        elif [[ -n "$current_file" ]]; then
+            if [[ $line == "+"* && $line != "+++"* ]]; then
+                added="${line:1}"
+                sanitized_data=$(strip_strings_and_comments "$added" "$in_block_comment")
+                in_block_comment=$(printf '%s\n' "$sanitized_data" | sed -n '1p')
+                sanitized=$(printf '%s\n' "$sanitized_data" | sed -n '2p')
+                if ! is_reported "$banned_reported" "$current_file" &&
+                    printf '%s\n' "$sanitized" | grep -qE "$banned"; then
+                    unsafe_found=$((unsafe_found + 1))
+                    ERRORS_FOUND+=("Banned function in $current_file (added line: $current_line)")
+                    banned_reported=$(mark_reported "$banned_reported" "$current_file")
+                fi
+                current_line=$((current_line + 1))
+            elif [[ $line == "-"* && $line != "---"* ]]; then
+                :
+            else
+                current_line=$((current_line + 1))
             fi
         fi
-    done
+    done <"$DIFF_CACHE"
 fi
 if [ $unsafe_found -gt 0 ]; then
-    report_result 1 "$unsafe_found file(s) contain unsafe functions"
+    report_result 1 "$unsafe_found file(s) add banned functions"
     RETURN=1
 else
     report_result 0
 fi
 
-# === CHECK 6: Static analysis ===
-update_progress "Running static analysis"
-if [ ${#C_FILES[@]} -gt 0 ]; then
-    existing_c_files=()
-    for file in "${C_FILES[@]}"; do
-        [ -f "$file" ] && existing_c_files+=("$file")
+# === CHECK 7: TODO/FIXME comments (newly added lines only) ===
+update_progress "Checking for TODO/FIXME comments"
+todo_found=0
+if [ ${#C_FILES_CHANGED[@]} -gt 0 ] && [ -s "$DIFF_CACHE" ]; then
+    current_file=""
+    reported=""
+    while IFS= read -r line; do
+        if [[ $line == "+++ b/"* ]]; then
+            current_file="${line#'+++ b/'}"
+            reported=""
+        elif [[ -z "$reported" && -n "$current_file" && $line == "+"* && $line != "+++"* ]]; then
+            if echo "$line" | grep -iqwE 'TODO|FIXME|HACK|XXX'; then
+                todo_found=$((todo_found + 1))
+                ERRORS_FOUND+=("TODO/FIXME comment added in $current_file")
+                reported=1
+            fi
+        fi
+    done <"$DIFF_CACHE"
+fi
+if [ $todo_found -gt 0 ]; then
+    report_result 1 "$todo_found file(s) introduce TODO/FIXME comments"
+    RETURN=1
+else
+    report_result 0
+fi
+
+# === CHECK 8: Security patterns (newly added lines only) ===
+# Uses bash [[ =~ ]] for pattern matching -- no subprocess per line.
+update_progress "Checking security patterns"
+sec_found=0
+
+# Pre-compile regex patterns for bash =~ (ERE syntax).
+re_printf_call='(^|[^[:alnum:]_])(printf|vprintf)[[:space:]]*\('
+re_printf_lit='(^|[^[:alnum:]_])(printf|vprintf)[[:space:]]*\([[:space:]]*"'
+re_fprintf_call='(^|[^[:alnum:]_])(fprintf|dprintf|vfprintf)[[:space:]]*\('
+re_fprintf_lit='(^|[^[:alnum:]_])(fprintf|dprintf|vfprintf)[[:space:]]*\([^,]*,[[:space:]]*"'
+re_snprintf_call='(^|[^[:alnum:]_])v?snprintf[[:space:]]*\('
+re_snprintf_lit='(^|[^[:alnum:]_])v?snprintf[[:space:]]*\([^,]*,[^,]*,[[:space:]]*"'
+re_format_ok='format-ok'
+re_open='(^|[^[:alnum:]_])open[[:space:]]*\('
+re_open_ok='O_CLOEXEC|openat|"r[ewab]*e"'
+re_pipe='(^|[^[:alnum:]_])pipe[[:space:]]*\('
+re_pipe_ok='pipe2'
+re_socket='(^|[^[:alnum:]_])socket[[:space:]]*\('
+re_socket_ok='SOCK_CLOEXEC'
+re_accept='(^|[^[:alnum:]_])accept[[:space:]]*\('
+re_accept_ok='accept4'
+re_pos_errno='return[[:space:]]+(E(PERM|ACCES|NOENT|FAULT|INVAL|NOSYS|BADF|EXIST|NODEV|NOTDIR|ISDIR|NFILE|MFILE|NOTTY|FBIG|NOSPC|ROFS|NAMETOOLONG|NOTEMPTY|LOOP|NOMEM|RANGE|OVERFLOW))[^[:alnum:]_]'
+re_neg_errno='return[[:space:]]+-E'
+re_malloc_mul='(^|[^[:alnum:]_])malloc[[:space:]]*\([^)]*\*'
+re_malloc_ok='calloc|reallocarray|__builtin_mul_overflow|overflow-ok'
+re_scanf_call='[vf]?s?scanf[[:space:]]*\('
+re_scanf_bare='%[^0-9"]*s|%[^0-9"]*\['
+re_threadsafe='(^|[^[:alnum:]_])(strtok|asctime|ctime|gmtime|localtime)[[:space:]]*\('
+re_threadsafe_ok='(strtok_r|asctime_r|ctime_r|gmtime_r|localtime_r)'
+
+if [ ${#C_FILES_CHANGED[@]} -gt 0 ] && [ -s "$DIFF_CACHE" ]; then
+    current_file=""
+    sec_reported=""
+    while IFS= read -r line; do
+        if [[ $line == "+++ b/"* ]]; then
+            current_file="${line#'+++ b/'}"
+        elif [[ -n "$current_file" && $line == "+"* && $line != "+++"* ]]; then
+            added="${line:1}"
+
+            # 8a. Non-literal format string (per-family argument position).
+            if ! is_reported "$sec_reported" "$current_file:fmtstr"; then
+                flagged=0
+                # printf/vprintf: format is arg 1
+                if [[ $added =~ $re_printf_call ]] && ! [[ $added =~ $re_printf_lit ]]; then
+                    flagged=1
+                fi
+                # fprintf/dprintf/vfprintf: format is arg 2
+                if [[ $flagged -eq 0 && $added =~ $re_fprintf_call ]] && ! [[ $added =~ $re_fprintf_lit ]]; then
+                    flagged=1
+                fi
+                # snprintf/vsnprintf: format is arg 3
+                if [[ $flagged -eq 0 && $added =~ $re_snprintf_call ]] && ! [[ $added =~ $re_snprintf_lit ]]; then
+                    flagged=1
+                fi
+                # Allow suppression comment.
+                if [[ $flagged -eq 1 ]] && [[ $added =~ $re_format_ok ]]; then
+                    flagged=0
+                fi
+                if [[ $flagged -eq 1 ]]; then
+                    sec_found=$((sec_found + 1))
+                    ERRORS_FOUND+=("Possible non-literal format string in $current_file")
+                    sec_reported=$(mark_reported "$sec_reported" "$current_file:fmtstr")
+                fi
+            fi
+
+            # 8b. Missing O_CLOEXEC on descriptor-creating calls.
+            if ! is_reported "$sec_reported" "$current_file:cloexec"; then
+                if [[ $added =~ $re_open ]] && ! [[ $added =~ $re_open_ok ]]; then
+                    sec_found=$((sec_found + 1))
+                    ERRORS_FOUND+=("open() without O_CLOEXEC in $current_file")
+                    sec_reported=$(mark_reported "$sec_reported" "$current_file:cloexec")
+                elif [[ $added =~ $re_pipe ]] && ! [[ $added =~ $re_pipe_ok ]]; then
+                    sec_found=$((sec_found + 1))
+                    ERRORS_FOUND+=("pipe() without O_CLOEXEC in $current_file (use pipe2)")
+                    sec_reported=$(mark_reported "$sec_reported" "$current_file:cloexec")
+                elif [[ $added =~ $re_socket ]] && ! [[ $added =~ $re_socket_ok ]]; then
+                    sec_found=$((sec_found + 1))
+                    ERRORS_FOUND+=("socket() without SOCK_CLOEXEC in $current_file")
+                    sec_reported=$(mark_reported "$sec_reported" "$current_file:cloexec")
+                elif [[ $added =~ $re_accept ]] && ! [[ $added =~ $re_accept_ok ]]; then
+                    sec_found=$((sec_found + 1))
+                    ERRORS_FOUND+=("accept() without SOCK_CLOEXEC in $current_file (use accept4)")
+                    sec_reported=$(mark_reported "$sec_reported" "$current_file:cloexec")
+                fi
+            fi
+
+            # 8c. Positive errno return (should be -EFOO in seccomp dispatch).
+            if ! is_reported "$sec_reported" "$current_file:errno"; then
+                if [[ $added =~ $re_pos_errno ]] && ! [[ $added =~ $re_neg_errno ]]; then
+                    sec_found=$((sec_found + 1))
+                    ERRORS_FOUND+=("Positive errno return in $current_file (use -EFOO)")
+                    sec_reported=$(mark_reported "$sec_reported" "$current_file:errno")
+                fi
+            fi
+
+            # 8d. Unchecked malloc multiplication (integer overflow risk).
+            if ! is_reported "$sec_reported" "$current_file:malloc"; then
+                if [[ $added =~ $re_malloc_mul ]] && ! [[ $added =~ $re_malloc_ok ]]; then
+                    sec_found=$((sec_found + 1))
+                    ERRORS_FOUND+=("malloc() with multiplication in $current_file (use calloc or check overflow)")
+                    sec_reported=$(mark_reported "$sec_reported" "$current_file:malloc")
+                fi
+            fi
+
+            # 8e. scanf-family without width on %s or %[.
+            if ! is_reported "$sec_reported" "$current_file:scanf"; then
+                if [[ $added =~ $re_scanf_call ]] && [[ $added =~ $re_scanf_bare ]]; then
+                    sec_found=$((sec_found + 1))
+                    ERRORS_FOUND+=("scanf with unbounded %s or %[ in $current_file")
+                    sec_reported=$(mark_reported "$sec_reported" "$current_file:scanf")
+                fi
+            fi
+
+            # 8f. Thread-unsafe functions (use _r variants).
+            if ! is_reported "$sec_reported" "$current_file:threadsafe"; then
+                if [[ $added =~ $re_threadsafe ]] && ! [[ $added =~ $re_threadsafe_ok ]]; then
+                    sec_found=$((sec_found + 1))
+                    ERRORS_FOUND+=("Thread-unsafe function in $current_file (use _r variant)")
+                    sec_reported=$(mark_reported "$sec_reported" "$current_file:threadsafe")
+                fi
+            fi
+        fi
+    done <"$DIFF_CACHE"
+fi
+if [ $sec_found -gt 0 ]; then
+    report_result 1 "$sec_found security pattern(s) found in new code"
+    RETURN=1
+else
+    report_result 0
+fi
+
+# === CHECK 9: Compiler syntax check (via Makefile, Linux only) ===
+# Delegates to 'make check-syntax' which uses the project's real CFLAGS.
+# Skips gracefully on non-Linux compilers (handled inside the Makefile).
+update_progress "Compiler syntax check"
+if [ "$(uname -s)" = "Linux" ] && [ -f .config ]; then
+    staged_c_only=()
+    for file in "${C_FILES_CHANGED[@]}"; do
+        [[ $file == *.c ]] && [ -f "$STAGED_DIR/$file" ] && staged_c_only+=("$file")
     done
-    if [ ${#existing_c_files[@]} -gt 0 ]; then
-        if ! cppcheck $CPPCHECK_OPTS "${existing_c_files[@]}" > /dev/null 2>&1; then
+    if [ ${#staged_c_only[@]} -gt 0 ]; then
+        compiler_errors="$HOOK_TMPDIR/compiler_errors"
+        # Run make from the staged dir so -Iinclude/-Isrc resolve to staged headers.
+        # -I adds the repo root to the makefile include search path so
+        # "include mk/toolchain.mk" etc. resolve from the working tree.
+        if ! make -I "$workspace" -f "$workspace/Makefile" -C "$STAGED_DIR" \
+            check-syntax CHK_SOURCES="${staged_c_only[*]}" \
+            2>"$compiler_errors" >/dev/null; then
+            report_result 1 "Compiler syntax check failed"
+            while IFS= read -r eline; do
+                ERRORS_FOUND+=("$eline")
+            done < <(grep -E '(error|warning):' "$compiler_errors" | head -10)
+            RETURN=1
+        else
+            report_result 0
+        fi
+    else
+        report_result 0
+    fi
+else
+    printf " [ ${YELLOW}SKIP${NC} ] (Linux + .config required)\n"
+fi
+
+# === CHECK 10: Static analysis - cppcheck (git-tracked files only) ===
+update_progress "Running cppcheck"
+if [ ${#C_FILES_CHANGED[@]} -gt 0 ]; then
+    staged_c_files=()
+    has_header_changes=0
+    for file in "${C_FILES_CHANGED[@]}"; do
+        if [[ $file == *.c ]] && [ -f "$STAGED_DIR/$file" ]; then
+            staged_c_files+=("$file")
+        elif [[ $file == *.h ]]; then
+            has_header_changes=1
+        fi
+    done
+    # Header-only changes can break any translation unit.
+    # Fall back to all tracked src/*.c so cppcheck catches the breakage.
+    if [ ${#staged_c_files[@]} -eq 0 ] && [ $has_header_changes -eq 1 ]; then
+        while IFS= read -r -d '' f; do
+            [ -f "$STAGED_DIR/$f" ] && staged_c_files+=("$f")
+        done < <(git ls-files -z -- 'src/*.c')
+    fi
+    if [ ${#staged_c_files[@]} -gt 0 ]; then
+        cppcheck_opts="-I. -Iinclude -Isrc"
+        cppcheck_opts+=" --enable=all --error-exitcode=1"
+        cppcheck_opts+=" --library=posix --platform=unix64"
+        cppcheck_opts+=" $CACHED_CC_STD"
+        cppcheck_opts+=" --max-configs=8 $CACHED_SUPPRESSIONS"
+        cppcheck_opts+=" -D_GNU_SOURCE -D__linux__"
+        cppcheck_log="$HOOK_TMPDIR/cppcheck.log"
+        if ! (
+            cd "$STAGED_DIR" &&
+                cppcheck $cppcheck_opts "${staged_c_files[@]}"
+        ) >/dev/null 2>"$cppcheck_log"; then
             report_result 1 "Static analysis errors found"
+            while IFS= read -r cline; do
+                ERRORS_FOUND+=("cppcheck: $cline")
+            done < <(grep -E '(error|warning):' "$cppcheck_log" | head -10)
             RETURN=1
         else
             report_result 0
@@ -269,10 +677,10 @@ else
     report_result 0
 fi
 
-# === CHECK 7: Non-ASCII filenames ===
+# === CHECK 11: Non-ASCII filenames (checked from FILES array, no extra git call) ===
 update_progress "Checking filenames"
-if test $(git diff --cached --name-only --diff-filter=A -z \
-    | LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0; then
+non_ascii_count=$(printf '%s\n' "${FILES[@]}" | LC_ALL=C tr -d '[ -~]\n' | wc -c | awk '{print $1}')
+if [ "$non_ascii_count" != "0" ]; then
     report_result 1 "Non-ASCII filename detected"
     RETURN=1
 else
@@ -281,18 +689,12 @@ fi
 
 printf "\r%*s\r" 50 ""
 
+# --- Summary (FILE_SUMMARIES already populated from initial numstat) ---
 printf "\n"
-
 printf "${CYAN}Files to be committed:${NC}\n"
-for file in "${FILES[@]}"; do
-    summary=$(git diff --cached --numstat "$file" 2> /dev/null | awk '{
-    if ($1 != "0" && $2 != "0")
-      printf "+%s/-%s", $1, $2;
-    else if ($1 != "0")
-      printf "+%s", $1;
-    else if ($2 != "0")
-      printf "-%s", $2;
-  }')
+for i in "${!FILES[@]}"; do
+    file="${FILES[$i]}"
+    summary="${FILE_SUMMARIES[$i]}"
     if [ -n "$summary" ]; then
         printf "  ${WHITE}%-40s${NC} ${GREEN}%s${NC}\n" "$file" "$summary"
     else

--- a/scripts/prepare-commit-msg.hook
+++ b/scripts/prepare-commit-msg.hook
@@ -7,7 +7,7 @@ COMMIT_SOURCE="$2"
 
 # Only add guidance for new, interactive commits (no source = editor opened).
 case "$COMMIT_SOURCE" in
-    message | template | merge | squash | commit) exit 0 ;;
+message | template | merge | squash | commit) exit 0 ;;
 esac
 
 # If the message already has non-comment content (e.g. -m flag), skip.
@@ -21,7 +21,7 @@ CHANGED_FILES_COMMENTED=$(echo "$CHANGED_FILES" | sed 's/^/# - /')
 
 {
     echo
-    cat << 'EOF'
+    cat <<'EOF'
 #
 # Commit message rules (enforced by commit-msg hook):
 #  1. Separate subject from body with a blank line
@@ -41,4 +41,4 @@ EOF
     else
         echo "# (no staged files)"
     fi
-} > "$COMMIT_MSG_FILE"
+} >"$COMMIT_MSG_FILE"

--- a/src/cli.c
+++ b/src/cli.c
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: MIT */
 
+#include <errno.h>
 #include <getopt.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -132,8 +134,9 @@ static int parse_image_args(int argc,
             break;
         case 'p': {
             char *end;
+            errno = 0;
             unsigned long v = strtoul(optarg, &end, 10);
-            if (*end != '\0') {
+            if (*end != '\0' || errno != 0 || v > UINT_MAX) {
                 fprintf(stderr, "invalid partition: %s\n", optarg);
                 return -1;
             }

--- a/src/identity.c
+++ b/src/identity.c
@@ -272,6 +272,9 @@ int kbox_parse_change_id(const char *spec, uid_t *uid, gid_t *gid)
     if (*end != '\0' || errno != 0)
         return -1;
 
+    if ((unsigned long) (uid_t) u != u || (unsigned long) (gid_t) g != g)
+        return -1;
+
     *uid = (uid_t) u;
     *gid = (gid_t) g;
     return 0;

--- a/tests/unit/test-cli.c
+++ b/tests/unit/test-cli.c
@@ -1,0 +1,49 @@
+/* SPDX-License-Identifier: MIT */
+
+#include "kbox/cli.h"
+#include "test-runner.h"
+
+/* On Linux, rewrite.c provides kbox_parse_syscall_mode.
+ * On macOS (unit-test-only builds), provide a minimal stub. */
+#ifndef __linux__
+int kbox_parse_syscall_mode(const char *value, enum kbox_syscall_mode *out)
+{
+    if (!value || !out)
+        return -1;
+    if (strcmp(value, "auto") == 0)
+        *out = KBOX_SYSCALL_MODE_AUTO;
+    else if (strcmp(value, "seccomp") == 0)
+        *out = KBOX_SYSCALL_MODE_SECCOMP;
+    else if (strcmp(value, "trap") == 0)
+        *out = KBOX_SYSCALL_MODE_TRAP;
+    else if (strcmp(value, "rewrite") == 0)
+        *out = KBOX_SYSCALL_MODE_REWRITE;
+    else
+        return -1;
+    return 0;
+}
+#endif
+
+static void test_parse_args_partition_valid(void)
+{
+    char *argv[] = {"kbox", "image", "-r", "rootfs.ext4", "-p", "7"};
+    struct kbox_args args;
+
+    ASSERT_EQ(kbox_parse_args(6, argv, &args), 0);
+    ASSERT_EQ(args.mode, KBOX_MODE_IMAGE);
+    ASSERT_EQ(args.image.part, 7);
+}
+
+static void test_parse_args_partition_overflow_rejected(void)
+{
+    char *argv[] = {"kbox", "image", "-r", "rootfs.ext4", "-p", "4294967296"};
+    struct kbox_args args;
+
+    ASSERT_EQ(kbox_parse_args(6, argv, &args), -1);
+}
+
+void test_cli_init(void)
+{
+    TEST_REGISTER(test_parse_args_partition_valid);
+    TEST_REGISTER(test_parse_args_partition_overflow_rejected);
+}

--- a/tests/unit/test-identity.c
+++ b/tests/unit/test-identity.c
@@ -128,6 +128,26 @@ static void test_parse_change_id_zero(void)
     ASSERT_EQ(gid, 0);
 }
 
+static void test_parse_change_id_rejects_uid_overflow(void)
+{
+    uid_t uid = 1;
+    gid_t gid = 2;
+
+    ASSERT_EQ(kbox_parse_change_id("4294967296:0", &uid, &gid), -1);
+    ASSERT_EQ(uid, 1);
+    ASSERT_EQ(gid, 2);
+}
+
+static void test_parse_change_id_rejects_gid_overflow(void)
+{
+    uid_t uid = 3;
+    gid_t gid = 4;
+
+    ASSERT_EQ(kbox_parse_change_id("0:4294967296", &uid, &gid), -1);
+    ASSERT_EQ(uid, 3);
+    ASSERT_EQ(gid, 4);
+}
+
 void test_identity_init(void)
 {
     TEST_REGISTER(test_hash_username_deterministic);
@@ -146,4 +166,6 @@ void test_identity_init(void)
     TEST_REGISTER(test_normalized_unknown_path);
     TEST_REGISTER(test_parse_change_id_valid);
     TEST_REGISTER(test_parse_change_id_zero);
+    TEST_REGISTER(test_parse_change_id_rejects_uid_overflow);
+    TEST_REGISTER(test_parse_change_id_rejects_gid_overflow);
 }

--- a/tests/unit/test-runner.c
+++ b/tests/unit/test-runner.c
@@ -91,6 +91,7 @@ void test_pass(void)
 /* Portable test suites (all hosts) */
 extern void test_fd_table_init(void);
 extern void test_path_init(void);
+extern void test_cli_init(void);
 extern void test_identity_init(void);
 extern void test_syscall_nr_init(void);
 extern void test_elf_init(void);
@@ -119,6 +120,7 @@ int main(int argc, char *argv[])
     /* Portable suites */
     test_fd_table_init();
     test_path_init();
+    test_cli_init();
     test_identity_init();
     test_syscall_nr_init();
     test_elf_init();


### PR DESCRIPTION
This rewrites pre-commit hook from 7 basic checks to 11, adding compiler-based syntax verification, security pattern detection, and expanded banned function enforcement. All checks now operate on staged index content via a materialized temp tree.

New checks:
 - Compiler -fsyntax-only pass (Linux only) with -Werror for format strings, implicit declarations, pointer type mismatches, and VLA
 - Security pattern scan on newly-added lines: non-literal format strings, missing O_CLOEXEC, positive errno returns, unchecked malloc multiplication, unbounded scanf, thread-unsafe functions
 - Expanded banned function list (13 functions)
 - Whitespace error detection via git diff --check
 - TODO/FIXME enforcement on new lines

Change-Id: Ic25657aaee3df44b155e92ae69e695c1c139f546

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Overhauls pre-commit and CI gates to enforce formatting, whitespace, syntax, and security on C/H changes. Splits CI into fast coding-style and static-analysis jobs; adds Linux-only syntax checks and strengthens CLI/identity parsing with tests.

- New Features
  - Pre-commit (11 checks; skipped in CI): staged tree with headers + `.config`; `clang-format-20`; `git diff --check`; merge-conflict guard; non-ASCII path/name checks; binary warnings; TODO/FIXME on new lines; 13 banned functions; security scan on added lines (non-literal format strings, missing CLOEXEC, positive errno returns, unchecked malloc multiplication, unbounded scanf, thread-unsafe calls); compiler `make check-syntax` (`-fsyntax-only`, Linux only); `cppcheck` on changed files.
  - CI: new `coding-style` (trailing newline + `clang-format-20`) and `static-analysis` (banned funcs, secret patterns, dangerous preprocessor + `cppcheck` with timeout) jobs run in parallel with unit/build; adds `.ci/check-*.sh` scripts to enforce these.
  - Tooling: tighter `.editorconfig`; hooks resolve paths robustly, respect Git `color.ui`, and skip in CI.

- Bug Fixes
  - cli: reject out-of-range partition values (errno checked, `UINT_MAX` capped); adds unit tests.
  - identity: reject UID/GID that overflow target types; adds unit tests.

<sup>Written for commit 341cd080f6277293a64b2c2f10ecb57c31ee2aef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

