### PR TITLE
Detect workflow file changes to trigger LKL build

### DIFF
--- a/.github/workflows/build-lkl.yml
+++ b/.github/workflows/build-lkl.yml
@@ -36,8 +36,12 @@ jobs:
       contents: read
     outputs:
       lkl_commit: ${{ steps.head.outputs.commit }}
+      yml_hash: ${{ steps.compare.outputs.yml_hash }}
       needs_build: ${{ steps.compare.outputs.needs_build }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
       - name: Get upstream LKL HEAD
         id: head
         run: |
@@ -54,6 +58,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          CURRENT_YML=$(sha256sum .github/workflows/build-lkl.yml | awk '{print $1}')
+          echo "yml_hash=${CURRENT_YML}" >> "$GITHUB_OUTPUT"
+
           if [ "${{ inputs.force }}" = "true" ]; then
             echo "needs_build=true" >> "$GITHUB_OUTPUT"
             echo "Forced rebuild requested."
@@ -61,18 +68,27 @@ jobs:
           fi
 
           # Fetch BUILD_INFO from existing nightly release.
-          LAST_COMMIT=$(gh release view "${{ env.NIGHTLY_TAG }}" \
+          LAST_RELEASE=$(gh release view "${{ env.NIGHTLY_TAG }}" \
             --repo "${{ env.KBOX_REPO }}" \
-            --json body --jq '.body' 2>/dev/null \
+            --json body --jq '.body' 2>/dev/null) || LAST_RELEASE=""
+
+          LAST_COMMIT=$(echo "$LAST_RELEASE" \
             | grep -oP 'commit=\K[0-9a-f]+' | head -1) || LAST_COMMIT=""
 
-          CURRENT="${{ steps.head.outputs.commit }}"
-          if [ "$LAST_COMMIT" = "$CURRENT" ]; then
-            echo "needs_build=false" >> "$GITHUB_OUTPUT"
-            echo "Upstream unchanged (${CURRENT}). Skipping build."
-          else
+          LAST_YML=$(echo "$LAST_RELEASE" \
+            | grep -oP 'yml_hash=\K[0-9a-f]+' | head -1) || LAST_YML=""
+
+          CURRENT_COMMIT="${{ steps.head.outputs.commit }}"
+
+          if [ "$LAST_COMMIT" != "$CURRENT_COMMIT" ]; then
             echo "needs_build=true" >> "$GITHUB_OUTPUT"
-            echo "New upstream commit: ${CURRENT} (was: ${LAST_COMMIT:-none})"
+            echo "New upstream commit: ${CURRENT_COMMIT} (was: ${LAST_COMMIT:-none})"
+          elif [ "$LAST_YML" != "$CURRENT_YML" ]; then
+            echo "needs_build=true" >> "$GITHUB_OUTPUT"
+            echo "build-lkl.yml was changed"
+          else
+            echo "needs_build=false" >> "$GITHUB_OUTPUT"
+            echo "Upstream unchanged (${CURRENT_COMMIT}) and the build script unchanged. Skipping build."
           fi
 
   # ---- Build x86_64, aarch64 and riscv64 in parallel ----
@@ -144,12 +160,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           LKL_COMMIT="${{ needs.check-upstream.outputs.lkl_commit }}"
+          YML_HASH="${{ needs.check-upstream.outputs.yml_hash }}"
           BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
           cat > /tmp/release-notes.md <<EOF
           Nightly prebuilt liblkl.a for kbox.
 
           commit=${LKL_COMMIT}
+          yml_hash=${YML_HASH}
           date=${BUILD_DATE}
           upstream=https://github.com/${{ env.LKL_UPSTREAM }}/commit/${LKL_COMMIT}
 


### PR DESCRIPTION
Previously, the nightly LKL build only checked the hash of the LKL commit, so the build process will only be triggered when the upstream LKL has new commit. However, when the build-lkl.yml is updated, the LKL should be rebuilt.

This checks not only the LKL commit hash but the hash of build-lkl.yml to ensure the build process is triggered when build-lkl.yml is updated.

This GitHub Action is tested on my repo. When the build-lkl.yml was updated, the build process was triggered[1] even if the upstream LKL remained the same as the last nightly LKL release. After that, when the other GitHub Action was run, the build process was not triggered[2] since the hash of build-lkl.yml remained the same. 

[1] https://github.com/rota1001/kbox/actions/runs/24188685186
[2] https://github.com/rota1001/kbox/actions/runs/24188694374

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Nightly LKL builds now trigger when either the upstream LKL commit changes or when the `build-lkl.yml` workflow changes. This makes sure workflow updates take effect immediately.

- **New Features**
  - Checkout repo in `check-upstream` to hash `.github/workflows/build-lkl.yml`.
  - Compute and expose `yml_hash`; trigger if upstream commit or `yml_hash` differ from the last nightly, otherwise skip.
  - Add `yml_hash` to release notes for traceability.

<sup>Written for commit 000074b44ca974aeef088102f7c60b8208777dba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

