### PR TITLE
Support incremental build for lkl

### DIFF
--- a/mk/deps.mk
+++ b/mk/deps.mk
@@ -7,7 +7,14 @@
 
 ifeq ($(FORCE_LKL_BUILD),1)
 
-$(LKL_LIB):
+# Always re-invoke the build script so the sub-make inside it can detect
+# source changes and perform an incremental rebuild of liblkl.a.
+# The FORCE sentinel (a phony with no recipe) makes Make treat $(LKL_LIB)
+# as always out of date, while the sub-make handles the actual incrementality.
+.PHONY: _lkl_force
+_lkl_force:
+
+$(LKL_LIB): _lkl_force
 	@echo "  BUILD   lkl (from source)"
 	$(Q)./scripts/build-lkl.sh $(ARCH)
 

--- a/scripts/build-lkl.sh
+++ b/scripts/build-lkl.sh
@@ -84,39 +84,41 @@ fi
 
 # ---- Configure -----------------------------------------------------------
 
-echo "  CONFIG  ARCH=lkl defconfig"
-make -C "${LKL_SRC}" ARCH=lkl defconfig
+if [ ! -f "${LKL_SRC}/.config" ]; then
+    echo "  CONFIG  ARCH=lkl defconfig"
+    make -C "${LKL_SRC}" ARCH=lkl defconfig
 
-# Enable features required by kbox (mirrors build-lkl.yml).
-for opt in \
-    CONFIG_DEVTMPFS \
-    CONFIG_DEVTMPFS_MOUNT \
-    CONFIG_DEVPTS_FS \
-    CONFIG_DEBUG_INFO \
-    CONFIG_GDB_SCRIPTS \
-    CONFIG_SCHED_DEBUG \
-    CONFIG_PROC_SYSCTL \
-    CONFIG_PRINTK \
-    CONFIG_TRACEPOINTS \
-    CONFIG_FTRACE \
-    CONFIG_DEBUG_FS; do
-    "${LKL_SRC}/scripts/config" --file "${LKL_SRC}/.config" --enable "${opt}"
-done
+    # Enable features required by kbox (mirrors build-lkl.yml).
+    for opt in \
+        CONFIG_DEVTMPFS \
+        CONFIG_DEVTMPFS_MOUNT \
+        CONFIG_DEVPTS_FS \
+        CONFIG_DEBUG_INFO \
+        CONFIG_GDB_SCRIPTS \
+        CONFIG_SCHED_DEBUG \
+        CONFIG_PROC_SYSCTL \
+        CONFIG_PRINTK \
+        CONFIG_TRACEPOINTS \
+        CONFIG_FTRACE \
+        CONFIG_DEBUG_FS; do
+        "${LKL_SRC}/scripts/config" --file "${LKL_SRC}/.config" --enable "${opt}"
+    done
 
-"${LKL_SRC}/scripts/config" --file "${LKL_SRC}/.config" \
-    --set-val CONFIG_DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT y
+    "${LKL_SRC}/scripts/config" --file "${LKL_SRC}/.config" \
+        --set-val CONFIG_DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT y
 
-for opt in \
-    CONFIG_MODULES \
-    CONFIG_SOUND \
-    CONFIG_USB_SUPPORT \
-    CONFIG_INPUT \
-    CONFIG_NFS_FS \
-    CONFIG_CIFS; do
-    "${LKL_SRC}/scripts/config" --file "${LKL_SRC}/.config" --disable "${opt}"
-done
+    for opt in \
+        CONFIG_MODULES \
+        CONFIG_SOUND \
+        CONFIG_USB_SUPPORT \
+        CONFIG_INPUT \
+        CONFIG_NFS_FS \
+        CONFIG_CIFS; do
+        "${LKL_SRC}/scripts/config" --file "${LKL_SRC}/.config" --disable "${opt}"
+    done
 
-make -C "${LKL_SRC}" ARCH=lkl olddefconfig
+    make -C "${LKL_SRC}" ARCH=lkl olddefconfig
+fi
 
 # ---- Build ---------------------------------------------------------------
 


### PR DESCRIPTION
When I am doing some experiment, I feel it would be more convenient if the top-level makefile considers the change in the lkl source and builds the new library regarding this.

Simply achieve this by forcing the run the make for lkl. So the sub-make under lkl should handle the incrementing automatically.

Change-Id: I699dc789634712239120709e183d47b82a3f3f13

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable incremental LKL builds by always invoking the LKL build script while letting the sub-make detect changes. This speeds up edit-build cycles by rebuilding only what changed.

- **New Features**
  - Make `$(LKL_LIB)` depend on a phony `_lkl_force` to always call `scripts/build-lkl.sh`, leaving incrementality to the sub-make.
  - In `scripts/build-lkl.sh`, run defconfig and config toggles only when `.config` is missing, reusing existing configs to avoid unnecessary reconfiguration.

<sup>Written for commit 0000f4e36a8458892edca3413d4c342163c084d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

