### PR TITLE
Ignore generated lkl-src and web-assets.c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ tests/stress/long-running
 tests/stress/rapid-fork
 tests/stress/signal-race
 !tests/stress/*.c
+build/lkl-src
+src/web-assets.c


### PR DESCRIPTION
The generated file sometime accidently be git-added, which is inconvenient. Ignore them.

Change-Id: Ie3173518807546dbd6d5f9c14dafaea8d87cf670

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `build/lkl-src` and `src/web-assets.c` to `.gitignore` to prevent accidental commits of generated files and keep diffs clean.

<sup>Written for commit 00008efa8c31585e6d8fa78cd24b3381e36f8fb2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

