### PR TITLE
Import rootless OCI image

### DIFF
--- a/.github/workflows/build-kbox.yml
+++ b/.github/workflows/build-kbox.yml
@@ -1,15 +1,16 @@
 # Build kbox and run full test suite.
 # Zero root required -- everything runs as an unprivileged user.
 #
-# Parallelism (4 independent jobs, 1 sequential):
-#   commit-hygiene -- Change-Id + subject format (needs full history)
-#   lint           -- clang-format, newline, security, cppcheck (one apt install)
-#   unit-tests     -- no LKL dependency, ASAN/UBSAN
-#   build-kbox     -- fetches LKL, compiles kbox + guest/stress bins, builds rootfs
-#   integration    -- needs build-kbox artifacts, runs integration + stress tests
+# Parallelism (5 independent jobs, 1 sequential):
+#   commit-hygiene  -- Change-Id + subject format (needs full history)
+#   lint            -- clang-format, newline, security, cppcheck (one apt install)
+#   unit-tests      -- no LKL dependency, ASAN/UBSAN
+#   build-kbox      -- fetches LKL, compiles kbox + guest/stress bins, builds rootfs
+#   oci-image-import -- pulls nginx:alpine via mkrootfs.sh --image, validates the
+#                       libext2fs-based ownership rewrite
+#   integration     -- needs build-kbox artifacts, runs integration + stress tests
 #
-# commit-hygiene, lint, unit-tests, and build-kbox run in parallel.
-# integration-tests waits for build-kbox only.
+# All independent jobs run in parallel. integration-tests waits for build-kbox only.
 name: Build and Test
 
 on:
@@ -145,6 +146,77 @@ jobs:
             tests/guest/*-test
             tests/stress/*
             !tests/stress/*.c
+
+  # ---- OCI image import: pull nginx:alpine, validate ownership rewrite ----
+  # Exercises scripts/oci-pull.py + tools/oci-chown end-to-end. nginx:alpine
+  # has multi-layer pulls and a /etc/passwd entry for "nginx" (uid=101) even
+  # though its tar headers are 0:0; the rewrite must restore the on-disk
+  # owner to 0 (vs the invoking user's UID that mke2fs -d would inherit).
+  oci-image-import:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Cache apt packages
+        uses: actions/cache@v5
+        with:
+          path: ~/apt-cache
+          key: apt-oci-${{ runner.os }}-${{ hashFiles('.github/workflows/build-kbox.yml') }}
+      - name: Install dependencies
+        run: |
+          mkdir -p ~/apt-cache
+          sudo apt-get update
+          sudo apt-get install -y -o Dir::Cache::Archives=$HOME/apt-cache \
+            e2fsprogs libext2fs-dev
+
+      - name: Build oci-chown helper
+        run: make -C tools/oci-chown
+
+      - name: Pull nginx:alpine with --rewrite-uid
+        run: |
+          # pipefail: don't let `tee` mask a mkrootfs.sh failure.
+          # nounset: catch any typo'd $VAR before it silently expands to "".
+          set -euo pipefail
+          ROOTFS=/tmp/nginx-oci.ext4 ./scripts/mkrootfs.sh \
+            --image=docker://nginx:alpine \
+            --rewrite-uid \
+            256 2>&1 | tee /tmp/mkrootfs.log
+
+          # Helper must report at least one inode rewrite; without it the
+          # mke2fs-inherited invoking-user UID would silently leak through.
+          if ! grep -qE "rewrote [1-9][0-9]* inode" /tmp/mkrootfs.log; then
+            echo "::error::oci-chown reported no inode rewrites"
+            exit 1
+          fi
+
+      - name: Verify ownership round-trip
+        run: |
+          # /etc/nginx/nginx.conf is a stable file in nginx:alpine. Its tar
+          # header is uid=0/gid=0, so a successful rewrite ends at User=0.
+          # Without --rewrite-uid the inode would carry the runner's UID.
+          # debugfs format: "User:     N   Group:     M   Project:     P ..."
+          STAT=$(printf "stat /etc/nginx/nginx.conf\n" \
+            | debugfs /tmp/nginx-oci.ext4 2>/dev/null \
+            | awk '/^User:/ {print $2 " " $4; exit}')
+          OWNER=$(echo "$STAT" | awk '{print $1}')
+          GROUP=$(echo "$STAT" | awk '{print $2}')
+          echo "/etc/nginx/nginx.conf User=$OWNER Group=$GROUP"
+          if [ "$OWNER" != "0" ] || [ "$GROUP" != "0" ]; then
+            echo "::error::expected User=0/Group=0, got User=$OWNER/Group=$GROUP"
+            exit 1
+          fi
+
+          # Mode bits must survive the rewrite. /usr/sbin/nginx is +x (mode 0755).
+          MODE=$(printf "stat /usr/sbin/nginx\n" \
+            | debugfs /tmp/nginx-oci.ext4 2>/dev/null \
+            | awk '/^Inode:/ {for (i=1;i<=NF;i++) if ($i=="Mode:") print $(i+1); exit}')
+          echo "/usr/sbin/nginx Mode=$MODE"
+          if [ "$MODE" != "0755" ]; then
+            echo "::error::expected /usr/sbin/nginx mode 0755, got $MODE"
+            exit 1
+          fi
 
   # ---- Integration + stress tests: needs kbox binary + rootfs ----
   integration-tests:

--- a/README.md
+++ b/README.md
@@ -182,6 +182,24 @@ make rootfs                                       # host arch
 make ARCH=aarch64 CC=aarch64-linux-gnu-gcc rootfs # cross
 ```
 
+To pull from a Docker [v2 registry](https://distribution.github.io/distribution/spec/api/)
+instead, pass `--image=docker://...` to the rootfs script (no
+[`docker`](https://www.docker.com/) daemon required, `python3` stdlib
+only):
+
+```bash
+ROOTFS=alpine.ext4 ./scripts/mkrootfs.sh --image=docker://alpine:3.21
+ROOTFS=node.ext4   ./scripts/mkrootfs.sh --image=docker://node:alpine \
+                                         --rewrite-uid --size=512
+```
+
+`--rewrite-uid` restores OCI tar-header ownership into the ext4 inodes
+via [`tools/oci-chown`](tools/oci-chown/) (built on demand, links
+against [`libext2fs`](https://e2fsprogs.sourceforge.net/)) and is
+required for [`--root-id`](#selecting-an-interception-mode) guests.
+See [docs/oci-image-import.md](docs/oci-image-import.md) for the full
+pipeline, layer cache, and threat model.
+
 Run a guest binary:
 
 ```bash
@@ -229,6 +247,7 @@ Run `./kbox --help` for the full option list.
 | Three syscall interception tiers and auto selection | [docs/interception-tiers.md](docs/interception-tiers.md) |
 | Internal design: dispatch routing, FD table, shadow FDs, ABI translation | [docs/architecture.md](docs/architecture.md) |
 | Threat model and deployment tiers | [docs/security-model.md](docs/security-model.md) |
+| Building rootfs images from OCI registries | [docs/oci-image-import.md](docs/oci-image-import.md) |
 | Using kbox as an AI agent execution layer | [docs/ai-agents.md](docs/ai-agents.md) |
 | Web dashboard and telemetry endpoints | [docs/web-observatory.md](docs/web-observatory.md) |
 | GDB workflow and helper commands | [docs/gdb-workflow.md](docs/gdb-workflow.md) |

--- a/docs/oci-image-import.md
+++ b/docs/oci-image-import.md
@@ -1,0 +1,196 @@
+# OCI image import
+
+`kbox` can build a rootfs from any OCI image hosted on a Docker
+[v2 registry](https://distribution.github.io/distribution/spec/api/),
+not just the bundled Alpine minirootfs. Pass `--image=docker://...` to
+[`scripts/mkrootfs.sh`](../scripts/mkrootfs.sh) and the script pulls the
+image's manifest and layer blobs, applies them to a staging directory,
+and feeds the result into `mke2fs -d` exactly like the Alpine path.
+
+The implementation is rootless and depends only on `python3` (stdlib
+only) and `e2fsprogs` (already required for `mke2fs`). The optional
+`--rewrite-uid` flag adds an in-tree libext2fs helper
+([`tools/oci-chown`](../tools/oci-chown/)) for restoring OCI tar-header
+uid/gid/mode into ext4 inodes; it is built on demand and only required
+when the rootfs will be used with `kbox --root-id`.
+
+## Quick start
+
+```bash
+# Pull and build a rootfs from Docker Hub.
+ROOTFS=alpine.ext4 ./scripts/mkrootfs.sh --image=docker://alpine:3.21
+
+# Pin to a digest for reproducibility.
+ROOTFS=alpine.ext4 ./scripts/mkrootfs.sh \
+    --image=docker://alpine@sha256:1832327faf04...
+
+# Other registries (host:port supported).
+ROOTFS=node.ext4 ./scripts/mkrootfs.sh \
+    --image=docker://node:alpine --size=512
+
+# Restore OCI tar-header uid/gid/mode (required for --root-id).
+ROOTFS=node.ext4 ./scripts/mkrootfs.sh \
+    --image=docker://node:alpine --rewrite-uid
+
+# Run with kbox.
+./kbox -S node.ext4 --root-id -- /usr/bin/node --version
+
+# Manage the layer cache.
+python3 ./scripts/oci-pull.py prune                  # wipe
+python3 ./scripts/oci-pull.py prune --keep-bytes=2G  # keep newest 2 GB
+```
+
+`--image` accepts:
+
+- `docker://NAME[:TAG]` — `library/` prefix is implied for unscoped
+  Docker Hub names. Default tag is `latest`.
+- `docker://REGISTRY/REPO[:TAG]` — non-Docker-Hub registries
+  (`quay.io/...`, `ghcr.io/...`, host:port).
+- `docker://REPO@sha256:DIGEST` — pin to a content digest for
+  reproducibility. The digest may name either a single-arch image
+  manifest (in which case arch selection is a no-op) or an OCI index /
+  manifest list (in which case `oci-pull.py` still resolves it to the
+  matching `linux/<arch>` entry, just like a tag).
+
+## Pipeline
+
+```
+       --image=docker://...
+              │
+              ▼
+   ┌─────────────────────────┐
+   │ scripts/oci-pull.py     │  registry pull (urllib + bearer-token)
+   │  └ manifest list resolve│
+   │  └ layer fetch          │  → cache: $XDG_CACHE_HOME/kbox/oci-layers
+   │  └ apply (whiteouts,    │
+   │     hardlinks, symlinks)│
+   └────────────┬────────────┘
+                │ staging/  (+ optional manifest)
+                ▼
+   ┌─────────────────────────┐
+   │ mke2fs -d staging       │  rootless ext4 build
+   └────────────┬────────────┘
+                │ rootfs.ext4
+                ▼   (with --rewrite-uid only)
+   ┌─────────────────────────┐
+   │ tools/oci-chown         │  libext2fs inode rewrite
+   │  └ ext2fs_namei         │  → uid/gid/mode from OCI tar header
+   │  └ ext2fs_write_inode   │
+   └─────────────────────────┘
+```
+
+## Layer cache
+
+Layer blobs are content-addressed (sha256). The cache lives at
+`$XDG_CACHE_HOME/kbox/oci-layers/<sha256>` (default
+`~/.cache/kbox/oci-layers/`). Writes are atomic
+(`tempfile.mkstemp` + `os.replace`); reads re-hash the file and drop
+the entry on mismatch, so a corrupted cache is self-healing on the next
+pull. Pass `--no-cache` to bypass entirely; use `oci-pull.py prune` to
+clear or trim the cache.
+
+## Rootless ownership rewrite (`--rewrite-uid`)
+
+`mke2fs -d` inherits the invoking user's UID into ext4 inodes. Without
+intervention, the guest sees its own files owned by a non-root UID,
+which breaks setuid binaries and `apk add` install scripts when the
+guest is launched with `kbox --root-id` (forces guest uid=0).
+
+The fix runs in three steps:
+
+1. `oci-pull.py --manifest=PATH` records `(uid, gid, mode)` per file,
+   directory, and hardlink during layer apply. Symlinks are excluded
+   (`lchown` semantics aren't load-bearing for the kbox guest); device
+   nodes are excluded (rootless cannot `mknod`; `/dev` is mounted at
+   guest runtime). Records are NUL-separated:
+   `<uid>\t<gid>\t<mode_octal>\t<path>\0`.
+2. `mke2fs -d` builds the ext4 image with invoking-user ownership.
+3. `tools/oci-chown <image> <manifest>` opens the image read-write via
+   libext2fs, resolves each path through `ext2fs_namei`, and rewrites
+   `i_uid` (16-bit lo + hi), `i_gid` (16-bit lo + hi), and `i_mode`
+   permission bits (preserving type bits like `S_IFREG`/`S_IFDIR`).
+   `ext2fs_close` flushes.
+
+The helper is build-time-only: `tools/oci-chown/Makefile` links against
+`-lext2fs -lcom_err` from `e2fsprogs`. The kbox supervisor build is
+unchanged. `mkrootfs.sh --rewrite-uid` builds the helper on demand if
+the binary isn't present.
+
+When you don't pass `--root-id`, you don't need `--rewrite-uid`: the
+guest runs as the host user, host UID matches inode UID, and ownership
+is consistent.
+
+## Hardening
+
+The layer-apply path is the main attack surface (a malicious image
+could try to write outside the staging directory). Defenses:
+
+- **Path traversal.** `safe_join` strips leading `./` and `/` from tar
+  member names and rejects any `..` component before joining onto the
+  staging root.
+- **Symlink Zip Slip.** Each member's parent directory is realpath-checked
+  against the staging root before any write, unlink, or `chmod`. A
+  malicious layer that creates `staging/etc -> /etc` and then writes
+  `etc/passwd` is rejected because `realpath(staging/etc) = /etc`
+  doesn't sit under `realpath(staging)`. File writes additionally pass
+  `O_NOFOLLOW`, and pre-existing symlinks at the destination are
+  unlinked before `os.makedirs`/`os.chmod`.
+- **Hardlink source confinement.** Hardlink targets resolve through
+  `safe_join` (or its parent-relative variant for ustar-format
+  tarballs, which also runs through `safe_join` to reject `..` after
+  normalization). Absolute linknames are rejected. The resolved source
+  is realpath-checked against the staging root, and `os.link` is called
+  with `follow_symlinks=False` so a staging-resident symlink cannot
+  redirect the link to a host file.
+- **DoS caps.** `MAX_MANIFEST_BYTES=4 MB`, `MAX_BLOB_BYTES=8 GB`,
+  `MAX_TAR_MEMBERS=500_000`. Layer descriptors with declared size over
+  the blob cap are rejected before download; the streaming loop also
+  caps actual bytes received.
+- **Auth handling.** Bearer tokens are stripped on cross-host redirects
+  (compared by `netloc`, not just hostname, so a port-change redirect
+  on the same host also drops the token).
+- **Digest verification.** Every blob is sha256-verified in flight;
+  cache reads re-verify before use. Corrupted entries are removed and
+  re-fetched.
+- **Manifest validation in `oci-chown`.** Every record's uid/gid is
+  range-checked (`0 <= v <= UINT32_MAX`); leading sign or whitespace is
+  rejected. Mode bits outside `0o7777` are rejected. A manifest tail
+  missing the trailing NUL fails loudly with byte offset and record
+  index.
+
+The supervisor itself never reads the OCI image at runtime (`kbox`
+treats the resulting `.ext4` as opaque LKL filesystem state), so a
+mis-applied layer cannot escalate beyond the staging directory.
+
+## Limitations
+
+- Only `docker://` URIs are accepted. No `oci://` (local OCI layout
+  directories), no `containers-storage://`. Adding a local OCI layout
+  reader is a small follow-up if needed.
+- Mutable tags (e.g. `alpine:3.21`) are resolved on every pull. Pin to
+  a digest for reproducibility.
+- Cosign / notation signature verification is not implemented; treat
+  this as a development tool, not a supply-chain control.
+- Synthetic parent directories (created when a tarball omits explicit
+  parent dir entries) are recorded as `0:0:0755`. Well-formed OCI
+  layers always include explicit parent entries, so this only fires on
+  malformed input.
+- zstd-compressed layer support depends on Python's `tarfile`
+  capability (Python 3.14+ on most distros).
+
+## Acceptance
+
+Verified end-to-end on x86_64 (`node1`) and aarch64 (`arm`) hosts:
+
+| Scenario | Result |
+|---|---|
+| `alpine:3.21` round-trip | 185 inodes; busybox `User=0` after rewrite |
+| `node:alpine` round-trip | ~2880 inodes; `/home/node` `User=1000` (uid round-trip) |
+| Integration suite vs OCI rootfs | parity with baseline tarball rootfs |
+
+A CI job
+([`.github/workflows/build-kbox.yml`](../.github/workflows/build-kbox.yml))
+runs the full pipeline against `nginx:alpine` on every PR, verifying
+the helper reports a non-zero rewrite count and that
+`/etc/nginx/nginx.conf` ends up `User=0/Group=0` and `/usr/sbin/nginx`
+mode is `0755`.

--- a/scripts/mkrootfs.sh
+++ b/scripts/mkrootfs.sh
@@ -1,13 +1,15 @@
 #!/bin/sh
 # SPDX-License-Identifier: MIT
-# Build an ext4 rootfs image from Alpine minirootfs for kbox.
+# Build an ext4 rootfs image for kbox from Alpine minirootfs (default) or
+# an OCI image pulled from a v2 registry.
 #
-# Usage: ./scripts/mkrootfs.sh [SIZE_MB]
-#   SIZE_MB defaults to 128.
+# Usage:
+#   ./scripts/mkrootfs.sh [--image=docker://IMAGE[:TAG]] [--size=MB] [SIZE_MB]
 #
 # Prerequisites:
 #   - mke2fs (e2fsprogs) with -d support (e2fsprogs >= 1.43)
-#   - curl or wget (for downloading Alpine minirootfs)
+#   - curl or wget (for the default Alpine path)
+#   - python3 (for --image)
 #   - sha256sum
 #
 # The script builds the rootfs without requiring root privileges by using
@@ -15,9 +17,69 @@
 
 set -eu
 
-. "$(cd "$(dirname "$0")" && pwd)/common.sh"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "${SCRIPT_DIR}/common.sh"
 
-SIZE_MB="${1:-128}"
+SIZE_MB=128
+IMAGE=""
+REWRITE_UID=0
+
+# Validate that the size argument is a non-empty digit-only string.
+# Applied at all three entry points (--size=N, --size N, bare positional)
+# so a typo like `--size=abc` fails loudly instead of being assigned and
+# blowing up much later inside mke2fs.
+validate_size()
+{
+    case "$1" in
+        '' | *[!0-9]*) die "invalid size: ${1:-(empty)} (expected integer MB)" ;;
+    esac
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --image=*) IMAGE="${1#--image=}" ;;
+        --image)
+            shift
+            [ $# -gt 0 ] || die "--image requires an argument"
+            IMAGE="$1"
+            ;;
+        --size=*)
+            SIZE_MB="${1#--size=}"
+            validate_size "$SIZE_MB"
+            ;;
+        --size)
+            shift
+            [ $# -gt 0 ] || die "--size requires an argument"
+            validate_size "$1"
+            SIZE_MB="$1"
+            ;;
+        --rewrite-uid) REWRITE_UID=1 ;;
+        -h | --help)
+            cat << EOF
+Usage: $0 [--image=docker://IMAGE[:TAG]] [--size=MB] [--rewrite-uid] [SIZE_MB]
+  Build an ext4 rootfs at \$ROOTFS (default: alpine.ext4).
+  Without --image, fetch the Alpine minirootfs (default behavior).
+  With --image, pull the image from a v2 registry instead.
+  With --rewrite-uid (requires --image), restore OCI tar-header
+  uid/gid/mode into ext4 inodes via tools/oci-chown. Required when
+  the rootfs will be used with kbox --root-id.
+EOF
+            exit 0
+            ;;
+        -*) die "unknown option: $1 (try --help)" ;;
+        *)
+            # Backward compat: bare positional is SIZE_MB.
+            validate_size "$1"
+            SIZE_MB="$1"
+            ;;
+    esac
+    shift
+done
+
+if [ "$REWRITE_UID" = 1 ] && [ -z "$IMAGE" ]; then
+    die "--rewrite-uid requires --image"
+fi
+
 OUTFILE="${ROOTFS:-alpine.ext4}"
 GUEST_DIR="tests/guest"
 STRESS_DIR="tests/stress"
@@ -44,21 +106,38 @@ trap cleanup EXIT
 command -v mke2fs > /dev/null 2>&1 || die "mke2fs not found. Install e2fsprogs."
 command -v sha256sum > /dev/null 2>&1 || die "sha256sum not found."
 
-# Download Alpine minirootfs (cached in deps/).
-mkdir -p "$CACHE_DIR"
-TARBALL_PATH="${CACHE_DIR}/${ALPINE_TARBALL}"
-
-if [ ! -f "$TARBALL_PATH" ]; then
-    echo "Downloading Alpine minirootfs ${ALPINE_VERSION} (${ALPINE_ARCH})..."
-    download_file "$ALPINE_URL" "$TARBALL_PATH"
-fi
-
-verify_sha256 "$TARBALL_PATH" "$ALPINE_SHA256_FILE" "$ALPINE_TARBALL"
-
-# Create staging directory and extract Alpine rootfs.
 STAGING=$(mktemp -d)
-echo "Extracting Alpine minirootfs into staging..."
-tar xzf "$TARBALL_PATH" -C "$STAGING"
+
+if [ -n "$IMAGE" ]; then
+    command -v python3 > /dev/null 2>&1 \
+        || die "python3 not found (required for --image)."
+    echo "Pulling OCI image ${IMAGE}..."
+    MANIFEST_FLAG=""
+    OCI_MANIFEST=""
+    if [ "$REWRITE_UID" = 1 ]; then
+        OCI_MANIFEST=$(mktemp)
+        MANIFEST_FLAG="--manifest=${OCI_MANIFEST}"
+    fi
+    python3 "${SCRIPT_DIR}/oci-pull.py" pull \
+        --image="$IMAGE" \
+        --output="$STAGING" \
+        --arch="$ALPINE_ARCH" \
+        ${MANIFEST_FLAG}
+else
+    # Download Alpine minirootfs (cached in deps/).
+    mkdir -p "$CACHE_DIR"
+    TARBALL_PATH="${CACHE_DIR}/${ALPINE_TARBALL}"
+
+    if [ ! -f "$TARBALL_PATH" ]; then
+        echo "Downloading Alpine minirootfs ${ALPINE_VERSION} (${ALPINE_ARCH})..."
+        download_file "$ALPINE_URL" "$TARBALL_PATH"
+    fi
+
+    verify_sha256 "$TARBALL_PATH" "$ALPINE_SHA256_FILE" "$ALPINE_TARBALL"
+
+    echo "Extracting Alpine minirootfs into staging..."
+    tar xzf "$TARBALL_PATH" -C "$STAGING"
+fi
 
 # Ensure key directories exist.
 for d in bin sbin usr/bin usr/sbin lib lib64 etc tmp home root \
@@ -118,5 +197,20 @@ echo "Creating ${SIZE_MB}MB ext4 image at ${OUTFILE}..."
 mke2fs -t ext4 -d "$STAGING" -L kbox-rootfs \
     -b 4096 -r 1 -N 0 \
     "$OUTFILE" "${SIZE_MB}M" 2> /dev/null
+
+# Restore OCI tar-header uid/gid/mode in the ext4 inodes. mke2fs -d inherits
+# the invoking user's UID; with --root-id the guest would otherwise see its
+# own files owned by a non-root UID. Build the helper on demand.
+if [ "$REWRITE_UID" = 1 ]; then
+    OCI_CHOWN="${SCRIPT_DIR}/../tools/oci-chown/oci-chown"
+    if [ ! -x "$OCI_CHOWN" ]; then
+        echo "Building tools/oci-chown..."
+        ${MAKE:-make} -C "${SCRIPT_DIR}/../tools/oci-chown" > /dev/null \
+            || die "tools/oci-chown build failed (need libext2fs-dev?)"
+    fi
+    echo "Rewriting inode uid/gid/mode from OCI manifest..."
+    "$OCI_CHOWN" "$OUTFILE" "$OCI_MANIFEST"
+    rm -f "$OCI_MANIFEST"
+fi
 
 echo "OK: ${OUTFILE} ($(du -h "$OUTFILE" | cut -f1))"

--- a/scripts/oci-pull.py
+++ b/scripts/oci-pull.py
@@ -1,0 +1,672 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Pull an OCI image from a v2 registry and apply layers to a directory.
+
+Usage:
+    oci-pull.py pull  --image=docker://IMAGE[:TAG|@sha256:DIGEST]
+                      --output=DIR [--arch=x86_64|aarch64] [--no-cache]
+    oci-pull.py prune [--keep-bytes=N]
+
+Stdlib only. Supports Docker Hub and any registry implementing the
+distribution v2 spec with bearer-token auth.
+
+Layer blobs are cached at $XDG_CACHE_HOME/kbox/oci-layers (default
+~/.cache/kbox/oci-layers), keyed by sha256 digest. Cache reads are
+verified by re-hashing; corrupted entries are dropped and re-fetched.
+
+Mutable tags (e.g. 'latest', '3.21') are resolved on every pull. For
+reproducible builds, pin to a digest: docker://alpine@sha256:...
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import posixpath
+import re
+import shutil
+import stat
+import sys
+import tarfile
+import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+ACCEPT = ", ".join([
+    "application/vnd.docker.distribution.manifest.list.v2+json",
+    "application/vnd.oci.image.index.v1+json",
+    "application/vnd.docker.distribution.manifest.v2+json",
+    "application/vnd.oci.image.manifest.v1+json",
+])
+
+DEFAULT_REGISTRY = "registry-1.docker.io"
+HTTP_TIMEOUT = 60
+
+# DoS caps. Manifests are bounded by registry spec; blobs and tar member counts
+# are sized for typical Linux images (Debian: ~50K inodes, multi-GB total).
+MAX_MANIFEST_BYTES = 4 << 20            # 4 MB
+MAX_BLOB_BYTES = 8 << 30                # 8 GB
+MAX_TAR_MEMBERS = 500_000
+
+ARCH_MAP = {
+    "x86_64": "amd64",
+    "amd64": "amd64",
+    "aarch64": "arm64",
+    "arm64": "arm64",
+}
+
+
+class _StripAuthOnCrossHost(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        new_req = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if new_req is None:
+            return None
+        # Compare netloc (host:port), not just hostname, so a redirect to a
+        # different port on the same host still strips the bearer token.
+        if urllib.parse.urlparse(req.full_url).netloc != \
+                urllib.parse.urlparse(newurl).netloc:
+            new_req.headers.pop("Authorization", None)
+        return new_req
+
+
+_OPENER = urllib.request.build_opener(_StripAuthOnCrossHost())
+
+
+def _read_bounded(resp, max_bytes, what):
+    """Read up to max_bytes from a response. Exit on overflow."""
+    out = bytearray()
+    while True:
+        chunk = resp.read(1 << 16)
+        if not chunk:
+            return bytes(out)
+        if len(out) + len(chunk) > max_bytes:
+            sys.exit(f"error: {what} exceeds {max_bytes} bytes")
+        out.extend(chunk)
+
+
+def parse_image_ref(spec):
+    """Parse 'docker://[REGISTRY/]REPO[:TAG][@DIGEST]' into (registry, repo, ref).
+
+    'ref' is the digest if @DIGEST is present, otherwise the tag (default 'latest').
+    """
+    if not spec.startswith("docker://"):
+        sys.exit(f"error: image must start with 'docker://': {spec}")
+    rest = spec[len("docker://"):]
+
+    digest = None
+    if "@" in rest:
+        rest, digest = rest.rsplit("@", 1)
+
+    # Tag is the trailing ':TAG' on the LAST path component (so a host:port
+    # registry like reg.example:5000/foo is not mis-parsed as repo=reg.example).
+    last_slash = rest.rfind("/")
+    last_part = rest[last_slash + 1:] if last_slash >= 0 else rest
+    tag = "latest"
+    if ":" in last_part:
+        last_part, tag = last_part.rsplit(":", 1)
+        rest = (rest[:last_slash + 1] + last_part) if last_slash >= 0 else last_part
+
+    first_slash = rest.find("/")
+    if first_slash >= 0:
+        head = rest[:first_slash]
+        if "." in head or ":" in head or head == "localhost":
+            registry, repo = head, rest[first_slash + 1:]
+        else:
+            registry, repo = DEFAULT_REGISTRY, rest
+    else:
+        registry, repo = DEFAULT_REGISTRY, "library/" + rest
+
+    return registry, repo, digest if digest else tag
+
+
+class Client:
+    def __init__(self, registry):
+        self.registry = registry
+        self.token = None
+
+    def _open(self, url, accept):
+        headers = {"Accept": accept}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        return _OPENER.open(urllib.request.Request(url, headers=headers),
+                            timeout=HTTP_TIMEOUT)
+
+    def _refresh_token(self, www_auth):
+        m = re.match(r"Bearer\s+(.*)", www_auth or "")
+        if not m:
+            sys.exit(f"error: unsupported WWW-Authenticate: {www_auth!r}")
+        params = dict(re.findall(r'(\w+)="([^"]*)"', m.group(1)))
+        realm = params.pop("realm", None)
+        if not realm:
+            sys.exit(f"error: WWW-Authenticate missing realm: {www_auth!r}")
+        url = realm + ("?" + urllib.parse.urlencode(params) if params else "")
+        with _OPENER.open(url, timeout=HTTP_TIMEOUT) as r:
+            body = json.loads(_read_bounded(r, MAX_MANIFEST_BYTES, "auth token"))
+        self.token = body.get("token") or body.get("access_token")
+        if not self.token:
+            sys.exit("error: token endpoint returned no token")
+
+    def fetch(self, url, accept):
+        try:
+            resp = self._open(url, accept)
+        except urllib.error.HTTPError as e:
+            if e.code != 401:
+                raise
+            self._refresh_token(e.headers.get("WWW-Authenticate"))
+            resp = self._open(url, accept)
+        return _read_bounded(resp, MAX_MANIFEST_BYTES, "manifest/index")
+
+    def open_stream(self, url, accept):
+        try:
+            return self._open(url, accept)
+        except urllib.error.HTTPError as e:
+            if e.code != 401:
+                raise
+            self._refresh_token(e.headers.get("WWW-Authenticate"))
+            return self._open(url, accept)
+
+    def manifest_url(self, repo, ref):
+        return f"https://{self.registry}/v2/{repo}/manifests/{ref}"
+
+    def blob_url(self, repo, digest):
+        return f"https://{self.registry}/v2/{repo}/blobs/{digest}"
+
+
+def select_manifest(index, oci_arch):
+    """From a manifest list / OCI index, pick the linux/<arch> entry."""
+    candidates = [d for d in index.get("manifests", [])
+                  if d.get("platform", {}).get("os") == "linux"
+                  and d.get("platform", {}).get("architecture") == oci_arch]
+    if not candidates:
+        sys.exit(f"error: no linux/{oci_arch} manifest in index")
+    no_variant = [d for d in candidates if "variant" not in d.get("platform", {})]
+    return (no_variant or candidates)[0]
+
+
+def cache_root():
+    base = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache")
+    return os.path.join(base, "kbox", "oci-layers")
+
+
+def cache_path_for(digest):
+    return os.path.join(cache_root(), digest.replace(":", "_"))
+
+
+def hash_file(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 16), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def stream_blob(client, repo, digest, dest_path, declared_size=None):
+    """Stream a blob into dest_path, verifying its sha256 digest in flight.
+
+    If declared_size is provided (from the layer descriptor), reject early when
+    the advertised size exceeds MAX_BLOB_BYTES; the streaming loop also caps the
+    actual bytes received in case the registry advertises one size and serves
+    another.
+    """
+    if not digest.startswith("sha256:"):
+        sys.exit(f"error: unsupported digest algorithm: {digest}")
+    if declared_size is not None and declared_size > MAX_BLOB_BYTES:
+        sys.exit(f"error: layer {digest} declared size {declared_size} "
+                 f"exceeds cap {MAX_BLOB_BYTES}")
+    expected = digest.split(":", 1)[1]
+    h = hashlib.sha256()
+    resp = client.open_stream(client.blob_url(repo, digest),
+                              "application/octet-stream")
+    received = 0
+    with open(dest_path, "wb") as out:
+        while True:
+            chunk = resp.read(1 << 16)
+            if not chunk:
+                break
+            received += len(chunk)
+            if received > MAX_BLOB_BYTES:
+                os.unlink(dest_path)
+                sys.exit(f"error: layer {digest} streamed past cap "
+                         f"{MAX_BLOB_BYTES}")
+            h.update(chunk)
+            out.write(chunk)
+    if h.hexdigest() != expected:
+        os.unlink(dest_path)
+        sys.exit(f"error: digest mismatch for {digest}: got sha256:{h.hexdigest()}")
+
+
+def fetch_blob(client, repo, digest, declared_size=None, use_cache=True):
+    """Return a path to the verified blob. Cached if available, else downloaded."""
+    if use_cache:
+        cached = cache_path_for(digest)
+        if os.path.isfile(cached):
+            expected = digest.split(":", 1)[1]
+            if hash_file(cached) == expected:
+                print(f"    cache hit ({cached})", file=sys.stderr)
+                return cached, False
+            print(f"    cache corrupt, re-fetching ({cached})", file=sys.stderr)
+            os.unlink(cached)
+
+        os.makedirs(cache_root(), exist_ok=True)
+        # mkstemp gives a unique name in the same dir, so os.replace is atomic
+        # and concurrent writers don't collide on a PID-based name.
+        fd, tmp = tempfile.mkstemp(
+            prefix=os.path.basename(cached) + ".", suffix=".tmp",
+            dir=cache_root())
+        os.close(fd)
+        try:
+            stream_blob(client, repo, digest, tmp, declared_size)
+            os.replace(tmp, cached)
+        except BaseException:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+            raise
+        return cached, True
+
+    # No-cache path: stream into a fresh temp file the caller will discard.
+    fd, tmp = tempfile.mkstemp(prefix="kbox-oci-")
+    os.close(fd)
+    try:
+        stream_blob(client, repo, digest, tmp, declared_size)
+    except BaseException:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        raise
+    return tmp, True
+
+
+def safe_join(root, name):
+    """Resolve a tar member path against root, rejecting absolute and traversal."""
+    while name.startswith(("./", "/")):
+        name = name[2:] if name.startswith("./") else name[1:]
+    if not name:
+        return None
+    if any(p == ".." for p in name.split("/")):
+        return None
+    return os.path.join(root, name)
+
+
+def resolve_hardlink(root, member_name, linkname):
+    """Resolve a tar hardlink target. Per POSIX/GNU tar, linkname is the
+    archive-member name (root-relative). Some tarballs in the wild also use
+    parent-relative linknames; we accept those if they normalize to a path
+    inside the archive, but only after re-validating through safe_join (so
+    `..` traversal and absolute targets stay rejected).
+    """
+    candidates = []
+
+    direct = safe_join(root, linkname)
+    if direct is not None:
+        candidates.append(direct)
+
+    # Parent-relative interpretation. posixpath.join discards earlier
+    # components when linkname is absolute, so we must reject that here --
+    # otherwise an absolute linkname (e.g. "/etc/passwd") would resolve to
+    # a host path, escaping rootfs.
+    if not posixpath.isabs(linkname):
+        relative = posixpath.normpath(
+            posixpath.join(posixpath.dirname(member_name), linkname))
+        if (relative not in ("", ".")
+                and relative != ".."
+                and not relative.startswith("../")):
+            rel_path = safe_join(root, relative)
+            if rel_path is not None and rel_path not in candidates:
+                candidates.append(rel_path)
+
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if os.path.exists(candidate):
+            return candidate
+    return candidates[0]
+
+
+def _under_rootfs(rootfs_real, path):
+    """True if path resolves (via realpath) to a location inside rootfs_real.
+
+    Defends against a layer creating an in-staging symlink (e.g. etc -> /etc)
+    and a later member writing through it. realpath() resolves any symlinked
+    parent components; non-existent leaf components remain literal.
+    """
+    real = os.path.realpath(path)
+    return real == rootfs_real or real.startswith(rootfs_real + os.sep)
+
+
+def _record_ownership(ownership, path, info):
+    """Insert/update an ownership entry, pushing it to the END of the dict.
+
+    Manifest emission iterates the dict in insertion order, and the C helper
+    rewrites inodes by path. With hardlinks, two paths share one inode -- so
+    a stale sibling entry would overwrite a newer chmod on the same inode if
+    the dict still iterated in original-insertion order. pop+reinsert pushes
+    the most-recently-modified path last, so "last metadata op wins" on the
+    inode.
+    """
+    if ownership is None:
+        return
+    ownership.pop(path, None)
+    ownership[path] = info
+
+
+def _unlink_leaf_if_nondir(path):
+    """Remove an existing non-directory leaf without following symlinks."""
+    try:
+        st = os.lstat(path)
+    except FileNotFoundError:
+        return
+    if stat.S_ISDIR(st.st_mode):
+        return
+    os.unlink(path)
+
+
+def _ensure_parent_dirs(rootfs, path, ownership, _uid=None, _gid=None):
+    """Create missing parent dirs as 0:0:0755 (FHS default for system dirs).
+
+    Synthetic parents only fire on malformed archives that omit explicit
+    parent entries -- well-formed OCI layers include them in tree order, so
+    `lexists` short-circuits here. Defaulting to root-owned avoids leaking a
+    daemon UID (e.g. postgres) onto an ancestor when the child's uid/gid is
+    a non-root user. If a real layer member later targets the same path,
+    _record_ownership pop+reinserts so the explicit metadata wins.
+    """
+    rel_parent = os.path.relpath(os.path.dirname(path), rootfs)
+    if rel_parent == ".":
+        return
+    current = rootfs
+    for part in rel_parent.split(os.sep):
+        current = os.path.join(current, part)
+        if os.path.lexists(current):
+            continue
+        os.mkdir(current, 0o755)
+        _record_ownership(ownership,
+                          os.path.relpath(current, rootfs),
+                          (0, 0, 0o755))
+
+
+def apply_layer(tar_path, rootfs, ownership=None):
+    """Apply one OCI layer tarball to rootfs. Handles whiteouts and links.
+
+    If `ownership` is a dict, records {path: (uid, gid, mode)} for each
+    file/dir/hardlink. Whiteouts erase entries; later layers override.
+    Symlinks and device nodes are excluded (rootless cannot mknod, and
+    lchown semantics aren't useful for our threat model).
+    """
+    skipped_devnodes = 0
+    rootfs_real = os.path.realpath(rootfs)
+    members_seen = 0
+    with tarfile.open(tar_path, mode="r:*") as tf:
+        for member in tf:
+            members_seen += 1
+            if members_seen > MAX_TAR_MEMBERS:
+                sys.exit(f"error: tar member count exceeds {MAX_TAR_MEMBERS} "
+                         "(possible tar bomb)")
+            dest = safe_join(rootfs, member.name)
+            if dest is None:
+                print(f"  skip unsafe path: {member.name!r}", file=sys.stderr)
+                continue
+            base = os.path.basename(dest)
+
+            # Symlink-traversal guard. Check the parent (the leaf may not yet
+            # exist, and may itself be a symlink we're about to overwrite).
+            if not _under_rootfs(rootfs_real, os.path.dirname(dest)):
+                print(f"  skip symlink-escape parent for {member.name!r}",
+                      file=sys.stderr)
+                continue
+
+            if base == ".wh..wh..opq":
+                parent = os.path.dirname(dest)
+                if os.path.isdir(parent) and not os.path.islink(parent):
+                    for entry in os.listdir(parent):
+                        ep = os.path.join(parent, entry)
+                        if os.path.islink(ep) or not os.path.isdir(ep):
+                            os.unlink(ep)
+                        else:
+                            shutil.rmtree(ep, ignore_errors=True)
+                if ownership is not None:
+                    rel = os.path.relpath(parent, rootfs)
+                    prefix = (rel + os.sep) if rel != "." else ""
+                    for k in [k for k in ownership
+                              if k != "." and k.startswith(prefix)]:
+                        del ownership[k]
+                continue
+
+            if base.startswith(".wh."):
+                target = os.path.join(os.path.dirname(dest), base[len(".wh."):])
+                if os.path.islink(target) or os.path.isfile(target):
+                    os.unlink(target)
+                elif os.path.isdir(target):
+                    shutil.rmtree(target, ignore_errors=True)
+                if ownership is not None:
+                    rel = os.path.relpath(target, rootfs)
+                    prefix = rel + os.sep
+                    ownership.pop(rel, None)
+                    for k in [k for k in ownership if k.startswith(prefix)]:
+                        del ownership[k]
+                continue
+
+            mode = member.mode & 0o7777
+            uid = member.uid
+            gid = member.gid
+            try:
+                if member.isdir():
+                    _ensure_parent_dirs(rootfs, dest, ownership, uid, gid)
+                    # Replace any pre-existing symlink at dest before
+                    # makedirs/chmod, otherwise a malicious prior-layer
+                    # symlink would redirect chmod onto the host directory.
+                    if os.path.lexists(dest) and os.path.islink(dest):
+                        os.unlink(dest)
+                    os.makedirs(dest, exist_ok=True)
+                    os.chmod(dest, mode)
+                    _record_ownership(ownership,
+                                      os.path.relpath(dest, rootfs),
+                                      (uid, gid, mode))
+                elif member.issym():
+                    _ensure_parent_dirs(rootfs, dest, ownership, uid, gid)
+                    if os.path.lexists(dest):
+                        os.unlink(dest)
+                    os.symlink(member.linkname, dest)
+                elif member.islnk():
+                    link_dest = resolve_hardlink(rootfs, member.name,
+                                                 member.linkname)
+                    if link_dest is None:
+                        print(f"  skip unsafe hardlink: {member.linkname!r}",
+                              file=sys.stderr)
+                        continue
+                    # Realpath-confine the source: a previously-extracted
+                    # symlink in the staging tree could otherwise redirect
+                    # to a host path, and Python's os.link follows symlinks
+                    # via linkat(AT_SYMLINK_FOLLOW) by default. We also pass
+                    # follow_symlinks=False below as defense in depth.
+                    if not _under_rootfs(rootfs_real, link_dest):
+                        print(f"  skip symlink-escape hardlink source for "
+                              f"{member.name!r}", file=sys.stderr)
+                        continue
+                    if not os.path.exists(link_dest):
+                        # Forward-reference: tarfile cannot resolve a hardlink
+                        # whose target appears later in the archive (it only
+                        # searches earlier members). OCI layers in practice
+                        # always reference earlier members, so warn and skip.
+                        print(f"  warning: hardlink {member.name!r} -> "
+                              f"{member.linkname!r}: target not yet extracted",
+                              file=sys.stderr)
+                        continue
+                    _ensure_parent_dirs(rootfs, dest, ownership, uid, gid)
+                    if os.path.lexists(dest):
+                        os.unlink(dest)
+                    os.link(link_dest, dest, follow_symlinks=False)
+                    _record_ownership(ownership,
+                                      os.path.relpath(dest, rootfs),
+                                      (uid, gid, mode))
+                elif member.isfile():
+                    _ensure_parent_dirs(rootfs, dest, ownership, uid, gid)
+                    fobj = tf.extractfile(member)
+                    if fobj is not None:
+                        _unlink_leaf_if_nondir(dest)
+                        # Open with O_NOFOLLOW so a malicious pre-existing
+                        # symlink at dest cannot redirect the write.
+                        flags = (os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+                                 | os.O_NOFOLLOW)
+                        fd = os.open(dest, flags, mode)
+                        try:
+                            with os.fdopen(fd, "wb") as out:
+                                shutil.copyfileobj(fobj, out)
+                        finally:
+                            try:
+                                os.chmod(dest, mode)
+                            except OSError:
+                                pass
+                        _record_ownership(ownership,
+                                          os.path.relpath(dest, rootfs),
+                                          (uid, gid, mode))
+                elif member.ischr() or member.isblk() or member.isfifo():
+                    # Rootless cannot mknod; /dev is mounted at guest runtime.
+                    skipped_devnodes += 1
+            except OSError as exc:
+                print(f"  warning: {member.name}: {exc}", file=sys.stderr)
+    if skipped_devnodes:
+        print(f"  skipped {skipped_devnodes} device/fifo node(s) "
+              "(rootless cannot mknod; /dev is a runtime mount)",
+              file=sys.stderr)
+
+
+def is_index(manifest):
+    media = manifest.get("mediaType", "")
+    if "manifest.list" in media or "image.index" in media:
+        return True
+    return "manifests" in manifest and "layers" not in manifest
+
+
+def pull(image_url, output_dir, arch, use_cache=True, manifest_path=None):
+    oci_arch = ARCH_MAP.get(arch)
+    if not oci_arch:
+        sys.exit(f"error: unsupported arch: {arch}")
+
+    registry, repo, ref = parse_image_ref(image_url)
+    print(f"pulling {registry}/{repo}:{ref} ({oci_arch})", file=sys.stderr)
+
+    client = Client(registry)
+    manifest = json.loads(client.fetch(client.manifest_url(repo, ref), ACCEPT))
+
+    if is_index(manifest):
+        desc = select_manifest(manifest, oci_arch)
+        print(f"  selected {desc['digest'][:19]}...", file=sys.stderr)
+        manifest = json.loads(client.fetch(client.manifest_url(repo, desc["digest"]),
+                                           ACCEPT))
+
+    layers = manifest.get("layers", [])
+    if not layers:
+        sys.exit("error: manifest has no layers")
+
+    os.makedirs(output_dir, exist_ok=True)
+    ownership = {} if manifest_path else None
+    if ownership is not None:
+        # OCI layers rarely carry an explicit "/" entry, but the root inode
+        # still needs deterministic uid/gid/mode when mkrootfs rewrites it.
+        _record_ownership(ownership, ".", (0, 0, 0o755))
+    for i, layer in enumerate(layers):
+        digest = layer["digest"]
+        declared_size = layer.get("size")
+        print(f"  layer {i + 1}/{len(layers)}: {digest[:19]}...",
+              file=sys.stderr)
+        blob_path, ephemeral = fetch_blob(client, repo, digest,
+                                          declared_size, use_cache)
+        try:
+            apply_layer(blob_path, output_dir, ownership)
+        finally:
+            if ephemeral and not use_cache:
+                # No-cache: we wrote to a tempfile; clean it up.
+                try:
+                    os.unlink(blob_path)
+                except OSError:
+                    pass
+
+    if manifest_path is not None:
+        # NUL-separated records: <uid>\t<gid>\t<mode>\t<path>\0
+        # The root inode is emitted as path ".".
+        with open(manifest_path, "wb") as f:
+            for path, (uid, gid, mode) in ownership.items():
+                rec = f"{uid}\t{gid}\t{mode:o}\t{path}\0"
+                f.write(rec.encode("utf-8", "surrogateescape"))
+        print(f"  wrote ownership manifest: {manifest_path} "
+              f"({len(ownership)} entries)", file=sys.stderr)
+
+    print("done", file=sys.stderr)
+
+
+def prune(keep_bytes=0):
+    """Remove cached layer blobs. With keep_bytes>0, keep newest blobs up to budget."""
+    root = cache_root()
+    if not os.path.isdir(root):
+        print(f"cache empty: {root}", file=sys.stderr)
+        return
+
+    entries = []
+    for name in os.listdir(root):
+        full = os.path.join(root, name)
+        try:
+            st = os.stat(full)
+        except OSError:
+            continue
+        if not os.path.isfile(full):
+            continue
+        entries.append((st.st_mtime, st.st_size, full))
+
+    if keep_bytes > 0:
+        # Keep newest first; evict from the oldest end until under budget.
+        entries.sort(reverse=True)
+        running = 0
+        keep_count = 0
+        for mtime, size, full in entries:
+            if running + size <= keep_bytes:
+                running += size
+                keep_count += 1
+            else:
+                break
+        evict = entries[keep_count:]
+    else:
+        evict = entries
+
+    total = 0
+    for _, size, full in evict:
+        try:
+            os.unlink(full)
+            total += size
+        except OSError as exc:
+            print(f"  warning: {full}: {exc}", file=sys.stderr)
+    print(f"pruned {len(evict)} blob(s), {total} bytes from {root}",
+          file=sys.stderr)
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    pp = sub.add_parser("pull", help="pull an image into a directory")
+    pp.add_argument("--image", required=True,
+                    help="docker://[REGISTRY/]REPO[:TAG][@sha256:DIGEST]")
+    pp.add_argument("--output", required=True,
+                    help="staging directory to populate")
+    pp.add_argument("--arch", default=os.uname().machine,
+                    help="kbox arch (x86_64 or aarch64); default: host arch")
+    pp.add_argument("--no-cache", action="store_true",
+                    help="bypass the layer cache (don't read or write)")
+    pp.add_argument("--manifest", default=None,
+                    help="emit a uid/gid/mode manifest for tools/oci-chown")
+
+    pr = sub.add_parser("prune", help="remove cached layer blobs")
+    pr.add_argument("--keep-bytes", type=int, default=0,
+                    help="keep newest blobs up to this many bytes (default: 0 = wipe)")
+
+    args = p.parse_args()
+    if args.cmd == "pull":
+        pull(args.image, args.output, args.arch,
+             use_cache=not args.no_cache, manifest_path=args.manifest)
+    else:
+        prune(args.keep_bytes)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/oci-chown/Makefile
+++ b/tools/oci-chown/Makefile
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: MIT
+# Standalone build for oci-chown. Not part of the kbox supervisor build.
+# Linked against libext2fs from e2fsprogs. Run from this directory or via
+# `make -C tools/oci-chown`.
+
+CC       ?= cc
+CFLAGS   ?= -O2 -Wall -Wextra -Wpedantic -std=gnu11
+CPPFLAGS ?=
+LDFLAGS  ?=
+# error_message() comes from libcom_err (com_err is e2fsprogs's error tables).
+LDLIBS   := -lext2fs -lcom_err
+
+# pkg-config covers both ext2fs and com_err on most distros. Treat the
+# discovered include paths as preprocessor flags (CPPFLAGS) and the link
+# fragments as LDLIBS, so callers can still augment CFLAGS/LDFLAGS from
+# the environment without losing the pkg-config-discovered paths.
+PKG_CFLAGS := $(shell pkg-config --cflags ext2fs com_err 2>/dev/null)
+PKG_LIBS   := $(shell pkg-config --libs   ext2fs com_err 2>/dev/null)
+
+ifneq ($(PKG_CFLAGS),)
+CPPFLAGS += $(PKG_CFLAGS)
+endif
+ifneq ($(PKG_LIBS),)
+LDLIBS := $(PKG_LIBS)
+endif
+
+TARGET := oci-chown
+
+$(TARGET): oci-chown.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $< $(LDLIBS)
+
+clean:
+	rm -f $(TARGET)
+
+.PHONY: clean

--- a/tools/oci-chown/oci-chown.c
+++ b/tools/oci-chown/oci-chown.c
@@ -1,0 +1,222 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * oci-chown -- restore OCI tar-header uid/gid/mode into ext4 inodes.
+ *
+ * mke2fs -d inherits the invoking user's UID into ext4 inodes. When kbox is
+ * launched with --root-id (forces guest uid=0), the guest sees its own files
+ * owned by a non-root UID, breaking apk install scripts and setuid binaries.
+ * This helper opens the freshly-built ext4 image read-write via libext2fs and
+ * rewrites uid/gid/mode per inode from a manifest emitted by oci-pull.py.
+ *
+ * Manifest format (NUL-separated records):
+ *   <uid>\t<gid>\t<mode_octal>\t<path>\0
+ * The root inode may be addressed as "." (or "/" for compatibility).
+ * One record per regular file / directory / hardlink. Symlinks and device
+ * nodes are not in the manifest (rootless cannot mknod; lchown is irrelevant
+ * for our threat model -- the guest does not interpret symlink ownership).
+ *
+ * Build: make -C tools/oci-chown
+ * Usage: oci-chown <image.ext4> <manifest>
+ */
+
+#include <ext2fs/ext2fs.h>
+
+#include <ctype.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static int verbose = 0;
+
+static void __attribute__((noreturn, format(printf, 1, 2))) die(const char *fmt,
+                                                                ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    fputs("oci-chown: ", stderr);
+    vfprintf(stderr, fmt, ap); /* format-ok: callers pass literal fmt */
+    fputc('\n', stderr);
+    va_end(ap);
+    exit(1);
+}
+
+/*
+ * Read an entire file into memory. Caller frees *out_buf.
+ * Manifests are bounded in practice (~50K entries * 100 bytes = 5MB), so
+ * slurping is fine. We refuse anything over 64MB to bound memory.
+ */
+static void slurp(const char *path, char **out_buf, size_t *out_len)
+{
+    FILE *f = fopen(path, "rb");
+    if (!f)
+        die("open %s: %s", path, strerror(errno));
+    if (fseek(f, 0, SEEK_END) < 0)
+        die("fseek %s: %s", path, strerror(errno));
+    long len = ftell(f);
+    if (len < 0)
+        die("ftell %s: %s", path, strerror(errno));
+    if (len > (64L << 20))
+        die("manifest too large: %ld bytes", len);
+    rewind(f);
+
+    char *buf = malloc((size_t) len + 1);
+    if (!buf)
+        die("malloc");
+    if (len && fread(buf, 1, (size_t) len, f) != (size_t) len)
+        die("read %s: short", path);
+    buf[len] = '\0';
+    fclose(f);
+    *out_buf = buf;
+    *out_len = (size_t) len;
+}
+
+/*
+ * Parse a non-negative integer field terminated by `sep` from `s`. Stores
+ * the parsed value in *out and the position past the separator in *next.
+ * Returns 0 on success, -1 on parse error or overflow past `max`.
+ *
+ * Reject leading whitespace, signs, and empty fields -- the manifest emitter
+ * always produces clean digits.
+ */
+static int parse_field(const char *s,
+                       char sep,
+                       unsigned long max,
+                       unsigned long *out,
+                       char **next)
+{
+    if (!s || !*s || !isdigit((unsigned char) *s))
+        return -1;
+    errno = 0;
+    char *end;
+    unsigned long v = strtoul(s, &end, (sep == ' ') ? 8 : 10);
+    if (errno || *end != sep || v > max)
+        return -1;
+    *out = v;
+    *next = end + 1;
+    return 0;
+}
+
+/*
+ * Apply one record. Returns 0 on success, -1 on parse failure or namei miss.
+ * Lookup misses are warnings, not fatal: a manifest entry may correspond to
+ * a path that mke2fs -d skipped (e.g. dangling symlink target).
+ */
+static int apply_record(ext2_filsys fs, const char *rec)
+{
+    /* parse_field uses base 10 for sep != ' '; we use TAB everywhere here.
+     * The mode field is octal in the manifest, parsed manually below. */
+    char *p;
+    unsigned long uid;
+    if (parse_field(rec, '\t', UINT32_MAX, &uid, &p) < 0)
+        return -1;
+    unsigned long gid;
+    if (parse_field(p, '\t', UINT32_MAX, &gid, &p) < 0)
+        return -1;
+
+    /* mode is octal. */
+    if (!*p || !isdigit((unsigned char) *p))
+        return -1;
+    errno = 0;
+    char *end;
+    unsigned long mode = strtoul(p, &end, 8);
+    if (errno || *end != '\t' || (mode & ~0007777UL))
+        return -1;
+    p = end + 1;
+
+    const char *path = p;
+    if (!*path)
+        return -1;
+
+    ext2_ino_t ino;
+    errcode_t err;
+    if (strcmp(path, ".") == 0 || strcmp(path, "/") == 0) {
+        ino = EXT2_ROOT_INO;
+        err = 0;
+    } else {
+        err = ext2fs_namei(fs, EXT2_ROOT_INO, EXT2_ROOT_INO, path, &ino);
+    }
+    if (err) {
+        if (verbose)
+            fprintf(stderr, "  namei %s: %s\n", path, error_message(err));
+        return -1;
+    }
+
+    struct ext2_inode inode;
+    err = ext2fs_read_inode(fs, ino, &inode);
+    if (err)
+        die("read_inode %s: %s", path, error_message(err));
+
+    inode.i_uid = (uint16_t) (uid & 0xFFFFu);
+    inode.osd2.linux2.l_i_uid_high = (uint16_t) ((uid >> 16) & 0xFFFFu);
+    inode.i_gid = (uint16_t) (gid & 0xFFFFu);
+    inode.osd2.linux2.l_i_gid_high = (uint16_t) ((gid >> 16) & 0xFFFFu);
+    /* Preserve i_mode's type bits (S_IFREG, S_IFDIR, ...); rewrite perms. */
+    inode.i_mode = (uint16_t) ((inode.i_mode & ~0007777u) | (mode & 0007777u));
+
+    err = ext2fs_write_inode(fs, ino, &inode);
+    if (err)
+        die("write_inode %s: %s", path, error_message(err));
+
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    if (getenv("OCI_CHOWN_VERBOSE"))
+        verbose = 1;
+    if (argc != 3) {
+        fprintf(stderr, "usage: %s <image.ext4> <manifest>\n", argv[0]);
+        return 2;
+    }
+    const char *image = argv[1];
+    const char *manifest = argv[2];
+
+    /* Initialize libext2fs error tables. */
+    initialize_ext2_error_table();
+
+    ext2_filsys fs;
+    errcode_t err =
+        ext2fs_open(image, EXT2_FLAG_RW, 0, 0, unix_io_manager, &fs);
+    if (err)
+        die("ext2fs_open %s: %s", image, error_message(err));
+
+    char *buf;
+    size_t buflen;
+    slurp(manifest, &buf, &buflen);
+
+    size_t applied = 0, failed = 0, rec_idx = 0;
+    char *p = buf;
+    char *end = buf + buflen;
+    while (p < end) {
+        char *rec_end = memchr(p, '\0', (size_t) (end - p));
+        if (!rec_end)
+            die("manifest tail not NUL-terminated at byte %zu (record #%zu)",
+                (size_t) (p - buf), rec_idx);
+        if (rec_end != p) {
+            if (apply_record(fs, p) == 0)
+                applied++;
+            else
+                failed++;
+        }
+        p = rec_end + 1;
+        rec_idx++;
+    }
+    free(buf);
+
+    err = ext2fs_close(fs);
+    if (err)
+        die("ext2fs_close: %s", error_message(err));
+
+    fprintf(stderr, "oci-chown: rewrote %zu inode(s)", applied);
+    if (failed)
+        fprintf(stderr, ", %zu missed", failed);
+    fputc('\n', stderr);
+    return 0;
+}


### PR DESCRIPTION
mkrootfs.sh has only ever extracted the bundled Alpine minirootfs tarball into a staging directory and fed that to mke2fs -d. This change adds a --image=docker://... mode so the same staging path can be populated from an arbitrary OCI image hosted on a v2 registry, then a --rewrite-uid mode that restores tar-header uid/gid/mode into the resulting ext4 inodes.

The implementation has three pieces:

scripts/oci-pull.py is a stdlib-only Python helper that resolves manifest lists by host arch, fetches layer blobs with bearer-token auth, applies them to a directory honoring whiteouts (.wh.NAME and .wh..wh..opq), hardlinks (archive-root or parent-relative ustar form), and OCI symlinks. Layer blobs are content-addressed and cached under $XDG_CACHE_HOME/kbox/oci-layers, with atomic-rename writes and verify-on-read so a corrupted cache self-heals.

tools/oci-chown is an in-tree libext2fs helper that opens the ext4 image read-write, walks a NUL-separated manifest emitted by oci-pull.py (uid TAB gid TAB mode TAB path), and rewrites each inode's uid/gid hi+lo halves and i_mode permission bits via ext2fs_namei + ext2fs_read_inode/write_inode. The helper builds with its own Makefile (-lext2fs -lcom_err) and is built on demand by mkrootfs.sh; the kbox supervisor build is unchanged.

scripts/mkrootfs.sh grows --image=URL, --size=MB, and --rewrite-uid flags. Backward compat for the positional SIZE_MB argument is preserved. When --rewrite-uid is set, oci-pull.py emits a manifest into a temp file, mke2fs runs as before, and oci-chown rewrites the inodes from the manifest before mkrootfs declares the image ready.

The layer-apply path is the principal attack surface and is hardened against malicious images:

- safe_join rejects '..' and absolute paths in tar member names.
- Each member's parent directory is realpath-checked against the staging root before any write/unlink/chmod, so an in-staging symlink (e.g. layer 1 creates etc -> /etc, layer 2 writes etc/passwd) cannot redirect onto the host.
- File writes use O_NOFOLLOW; pre-existing symlinks at the destination are unlinked first.
- Hardlink targets are resolved through safe_join (and a parent- relative variant for ustar tarballs that also runs through safe_join after normalization), absolute linknames are rejected, the resolved source is realpath-confined, and os.link is called with follow_symlinks=False so a staging-resident symlink cannot redirect the link to a host file.
- Bearer tokens are stripped on cross-host redirects compared by netloc, not just hostname, so a port-change redirect on the same host also drops the token.
- DoS caps: MAX_MANIFEST_BYTES=4 MB, MAX_BLOB_BYTES=8 GB, MAX_TAR_MEMBERS=500_000.
- Every blob is sha256-verified in flight; cache reads re-verify.

oci-chown's manifest parser range-checks uid/gid (0..UINT32_MAX), rejects leading sign or whitespace, rejects mode bits outside 07777, and dies loudly on a manifest tail missing the trailing NUL.

A new oci-image-import CI job pulls nginx:alpine end-to-end on every PR, asserts oci-chown reports a non-zero rewrite count, and verifies that /etc/nginx/nginx.conf ends up User=0/Group=0 and /usr/sbin/nginx mode is 0755.

Verified on x86_64 (node1) and aarch64 (arm) with alpine:3.21 (185 inodes rewritten) and node:alpine (~2880 inodes; /home/node round- trips at User=1000/Group=1000). Integration suite shows parity with the baseline tarball rootfs.

Close #17

Change-Id: Ic260ccce778a1de0875fc466cc8fde4c14e301a8

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds rootless OCI image import to the rootfs build. `scripts/mkrootfs.sh` can now pull `docker://...` images and optionally restore tar-header ownership into ext4 inodes.

- **New Features**
  - `scripts/mkrootfs.sh`: adds `--image=docker://...`, `--rewrite-uid`, and `--size=MB` (positional size still supported); Alpine tarball remains default; builds `tools/oci-chown` on demand; validates size; requires `python3` for `--image`.
  - `scripts/oci-pull.py`: stdlib-only puller with bearer auth; resolves multi-arch; applies layers (whiteouts, hardlinks, symlinks); content-addressed cache under `$XDG_CACHE_HOME/kbox/oci-layers` with sha256 verify and `prune`.
  - `tools/oci-chown`: `libext2fs` helper that rewrites inode uid/gid/mode from a manifest; required for `--root-id` guests; supervisor build unchanged.
  - Hardened layer apply: safe path joins, realpath confinement, `O_NOFOLLOW`, strict hardlink handling (`follow_symlinks=False`), token stripping on cross-host redirects, DoS caps, and digest verification.
  - Docs: added `docs/oci-image-import.md` and README usage.

- **CI**
  - New `oci-image-import` job pulls `nginx:alpine`, asserts non-zero inode rewrites, and verifies `/etc/nginx/nginx.conf` owner (0:0) and `/usr/sbin/nginx` mode (0755).

<sup>Written for commit 00008c5bb551396e1c4b143a59adaf60f8c5a269. Summary will update on new commits. <a href="https://cubic.dev/pr/sysprog21/kbox/pull/66?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

