### PR TITLE
Set HOME to /root for guest root

### DIFF
--- a/src/image.c
+++ b/src/image.c
@@ -950,6 +950,9 @@ int kbox_run_image(const struct kbox_image_args *args)
         if (kbox_apply_guest_identity(sysnrs, root_id, override_uid,
                                       override_gid) < 0)
             goto err_post_boot;
+
+        if (root_id || override_uid == 0)
+            setenv("HOME", "/root", 1);
     }
 
     /* Probe host features.  Rewrite mode skips seccomp-specific probes. */


### PR DESCRIPTION
When kbox runs as guest root, it previously inherited the host's HOME. Because this directory does not exist in the LKL filesystem, cd would fail with ENOENT and shell profiles wouldn't load.

Fix this by overriding HOME to /root when guest root is active.

Change-Id: I738dbea7b0bcca01c62c29f054d0d5b375a68d66

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set HOME to /root when running as guest root to avoid inheriting the host HOME. This fixes cd ENOENT errors and ensures shell profiles load in the LKL filesystem.

<sup>Written for commit 00002f635e5c2d251adcf84583fbefb14f2889fe. Summary will update on new commits. <a href="https://cubic.dev/pr/sysprog21/kbox/pull/69?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

