### PR TITLE
Add make perf and fd table constant lookup test

### DIFF
--- a/.github/workflows/build-kbox.yml
+++ b/.github/workflows/build-kbox.yml
@@ -91,6 +91,16 @@ jobs:
       - name: Run unit tests (ASAN/UBSAN)
         run: make check-unit
 
+  # ---- Perf tests: no sanitizers, only perf benchmarks ----
+  perf-tests:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run perf tests
+        run: make check-perf
+
   # ---- Build kbox + prepare rootfs ----
   build-kbox:
     runs-on: ubuntu-24.04

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__
 *.ext4
 /kbox
 tests/unit/test-runner
+tests/unit/test-perf
 deps/
 lkl-x86_64/
 lkl-aarch64/

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ KCONFIG_CONF := configs/Kconfig
 
 # Targets that don't require .config
 CONFIG_TARGETS    := config defconfig oldconfig savedefconfig clean distclean indent \
-                     check-unit check-syntax check-commitlog fetch-lkl build-lkl \
+                     check-unit check-perf check-syntax check-commitlog fetch-lkl build-lkl \
                      fetch-minislirp install-hooks guest-bins stress-bins rootfs
 CONFIG_GENERATORS := config defconfig oldconfig
 

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -5,6 +5,7 @@
 TEST_DIR   = tests/unit
 TEST_SRCS  = $(TEST_DIR)/test-runner.c \
              $(TEST_DIR)/test-fd-table.c \
+			 $(TEST_DIR)/test-fd-table-refcount.c \
              $(TEST_DIR)/test-path.c \
              $(TEST_DIR)/test-mount.c \
              $(TEST_DIR)/test-cli.c \

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -56,6 +56,7 @@ TEST_SUPPORT_SRCS += $(SRC_DIR)/rewrite.c \
 endif
 
 TEST_TARGET  = tests/unit/test-runner
+PERF_TARGET  = tests/unit/test-perf
 
 # Guest test programs (compiled statically, run inside kbox)
 GUEST_DIR    = tests/guest
@@ -72,7 +73,7 @@ ROOTFS       = alpine.ext4
 
 # ---- Test targets ----
 
-check: check-unit check-integration check-stress
+check: check-unit check-perf check-integration check-stress
 
 check-unit: $(TEST_TARGET)
 	@echo "  RUN     check-unit"
@@ -85,6 +86,19 @@ TEST_LDFLAGS = $(filter-out -L$(LKL_DIR) -L$(LKL_DIR)/lib,$(LDFLAGS))
 $(TEST_TARGET): $(TEST_SRCS) $(TEST_SUPPORT_SRCS) $(wildcard .config)
 	@echo "  LD      $@"
 	$(Q)$(CC) $(CFLAGS) -DKBOX_UNIT_TEST -o $@ $(TEST_SRCS) $(TEST_SUPPORT_SRCS) $(TEST_LDFLAGS) -lpthread
+
+check-perf: $(PERF_TARGET)
+	@echo "  RUN     check-perf"
+	$(Q)./$(PERF_TARGET)
+
+# Perf-test binary: strip debug/sanitizer flags from CFLAGS, force -O2.
+PERF_TEST_CFLAGS  := $(filter-out -O0 -O1 -O3 -g -g3 -fsanitize% -fno-omit-frame-pointer,$(CFLAGS)) \
+                     -Wno-unused-function -O2 -DKBOX_UNIT_TEST -DKBOX_PERF_TESTS -DKBOX_PERF_ONLY
+PERF_TEST_LDFLAGS := $(filter-out -L$(LKL_DIR) -L$(LKL_DIR)/lib -fsanitize%,$(LDFLAGS))
+
+$(PERF_TARGET): $(TEST_SRCS) $(TEST_SUPPORT_SRCS) $(wildcard .config)
+	@echo "  LD      $@"
+	$(Q)$(CC) $(PERF_TEST_CFLAGS) -o $@ $(TEST_SRCS) $(TEST_SUPPORT_SRCS) $(PERF_TEST_LDFLAGS) -lpthread
 
 check-integration: $(TARGET) guest-bins stress-bins $(ROOTFS)
 	@echo "  RUN     check-integration"
@@ -164,4 +178,4 @@ check-commitlog:
 	@echo "  RUN     check-commitlog"
 	$(Q)scripts/check-commitlog.sh
 
-.PHONY: check check-unit check-integration check-stress check-commitlog guest-bins stress-bins rootfs check-syntax
+.PHONY: check check-unit check-perf check-integration check-stress check-commitlog guest-bins stress-bins rootfs check-syntax

--- a/src/fd-table.c
+++ b/src/fd-table.c
@@ -101,6 +101,8 @@ static inline void rev_host_set(struct kbox_fd_table *t, long host_fd, long vfd)
 
     if (host_fd < 0 || (uint64_t) host_fd >= KBOX_HOST_FD_REVERSE_MAX)
         return;
+
+    t->host_fd_refs[host_fd]++;
     cur = t->host_to_vfd[host_fd];
     if (cur == KBOX_HOST_VFD_NONE || cur == (int32_t) vfd) {
         t->host_to_vfd[host_fd] = (int32_t) vfd;
@@ -116,7 +118,8 @@ static inline void rev_host_clear(struct kbox_fd_table *t,
                                   long host_fd,
                                   long vfd)
 {
-    if (host_fd < 0 || (uint64_t) host_fd >= KBOX_HOST_FD_REVERSE_MAX)
+    if (host_fd < 0 || (uint64_t) host_fd >= KBOX_HOST_FD_REVERSE_MAX ||
+        t->host_fd_refs[host_fd] == 0)
         return;
     /* Only the single-holder case can be cleared authoritatively. If
      * the slot is MULTI, leave it: we cannot prove this is the last
@@ -124,10 +127,26 @@ static inline void rev_host_clear(struct kbox_fd_table *t,
      * lookups correctly. If the slot is NONE or claims a different
      * vfd, we were not the indexed holder; nothing to do.
      */
-    if (t->host_to_vfd[host_fd] == (int32_t) vfd)
-        t->host_to_vfd[host_fd] = KBOX_HOST_VFD_NONE;
-}
 
+    t->host_fd_refs[host_fd]--;
+    if (t->host_fd_refs[host_fd] == 0) {
+        t->host_to_vfd[host_fd] = KBOX_HOST_VFD_NONE;
+    } else if (t->host_fd_refs[host_fd] == 1) {
+        /* 1. Try a normal search first */
+        long cur_vfd = kbox_fd_table_find_by_host_fd(t, host_fd);
+
+        /* 2. If the search tripped over the dying slot, hide it and search
+         * again */
+        if (cur_vfd == vfd) {
+            struct kbox_fd_entry *e = fd_lookup(t, vfd);
+            e->host_fd = -1;
+            cur_vfd = kbox_fd_table_find_by_host_fd(t, host_fd);
+            e->host_fd = host_fd;
+        }
+
+        t->host_to_vfd[host_fd] = cur_vfd;
+    }
+}
 static inline void lkl_ref_inc(struct kbox_fd_table *t, long lkl_fd)
 {
     if (lkl_fd >= 0 && (uint64_t) lkl_fd < KBOX_LKL_FD_REFMAX &&
@@ -154,8 +173,10 @@ void kbox_fd_table_init(struct kbox_fd_table *t)
         clear_fd_entry(&t->low_fds[i]);
     for (i = 0; i < KBOX_MID_FD_MAX; i++)
         clear_fd_entry(&t->mid_fds[i]);
-    for (i = 0; i < KBOX_HOST_FD_REVERSE_MAX; i++)
+    for (i = 0; i < KBOX_HOST_FD_REVERSE_MAX; i++) {
         t->host_to_vfd[i] = KBOX_HOST_VFD_NONE;
+        t->host_fd_refs[i] = 0;
+    }
     for (i = 0; i < KBOX_LKL_FD_REFMAX; i++)
         t->lkl_fd_refs[i] = 0;
     t->next_fd = KBOX_FD_BASE;

--- a/src/fd-table.h
+++ b/src/fd-table.h
@@ -66,6 +66,10 @@ struct kbox_fd_table {
      * kbox_fd_table_find_by_host_fd() on the close() hot path.
      */
     int32_t host_to_vfd[KBOX_HOST_FD_REVERSE_MAX];
+    /* Tracks how many VFDs point to a specific Host FD.
+     * This allows us to know when to downgrade from MULTI.
+     */
+    uint16_t host_fd_refs[KBOX_HOST_FD_REVERSE_MAX];
     /* Refcount: how many virtual fds currently reference each
      * lkl_fd. Replaces the O(n) lkl_fd_has_other_ref scan and the
      * still_ref loop in forward_close.

--- a/tests/unit/test-fd-table-refcount.c
+++ b/tests/unit/test-fd-table-refcount.c
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: MIT */
+#include <string.h>
+
+#include "fd-table.h"
+#include "test-runner.h"
+#define KBOX_HOST_VFD_NONE ((int32_t) -1)
+#define KBOX_HOST_VFD_MULTI ((int32_t) -2)
+
+static void test_fd_table_multi_downgrade_regression(void)
+{
+    struct kbox_fd_table t;
+    long vfd1, vfd2;
+    long host_fd = 42;
+
+    kbox_fd_table_init(&t);
+
+    vfd1 = kbox_fd_table_insert(&t, 10, 0);
+    kbox_fd_table_set_host_fd(&t, vfd1, host_fd);
+
+    ASSERT_EQ(t.host_to_vfd[host_fd], vfd1);
+    ASSERT_EQ(t.host_fd_refs[host_fd], 1);
+
+    /* MULTI state*/
+    vfd2 = kbox_fd_table_insert(&t, 20, 0);
+    kbox_fd_table_set_host_fd(&t, vfd2, host_fd);
+
+    ASSERT_EQ(t.host_to_vfd[host_fd], KBOX_HOST_VFD_MULTI);
+    ASSERT_EQ(t.host_fd_refs[host_fd], 2);
+
+    /* Downgrade back to Single*/
+    kbox_fd_table_remove(&t, vfd2);
+
+    ASSERT_EQ(t.host_to_vfd[host_fd], vfd1);
+    ASSERT_EQ(t.host_fd_refs[host_fd], 1);
+
+    /* Should return the exact vfd */
+    ASSERT_EQ(kbox_fd_table_find_by_host_fd(&t, host_fd), vfd1);
+}
+
+void test_fd_table_refcount_init(void)
+{
+    TEST_REGISTER(test_fd_table_multi_downgrade_regression);
+}

--- a/tests/unit/test-fd-table-refcount.c
+++ b/tests/unit/test-fd-table-refcount.c
@@ -37,7 +37,87 @@ static void test_fd_table_multi_downgrade_regression(void)
     ASSERT_EQ(kbox_fd_table_find_by_host_fd(&t, host_fd), vfd1);
 }
 
+#ifdef KBOX_PERF_TESTS
+#include <stdio.h>
+#include <time.h>
+#define PERF_ITERATIONS 1000000
+static double time_diff_ns(struct timespec *start, struct timespec *end)
+{
+    return ((double) (end->tv_sec - start->tv_sec) * 1e9) +
+           (double) (end->tv_nsec - start->tv_nsec);
+}
+
+static void test_fd_table_o1_characteristics(void)
+{
+    struct kbox_fd_table t;
+    int ns_to_test[] = {64, 256, 1024, 4096, 16384};
+    int num_sizes = sizeof(ns_to_test) / sizeof(ns_to_test[0]);
+
+    double baseline_present_ns = 0;
+    double baseline_absent_ns = 0;
+
+    printf("\n--- O(1) Characteristic Perf Test ---\n");
+
+    for (int i = 0; i < num_sizes; i++) {
+        int n = ns_to_test[i];
+        kbox_fd_table_init(&t);
+        long target_present = 0;
+        long target_absent = 65535;
+
+        for (long j = 0, host_fd = 0; j < n; j++) {
+            long vfd = j;
+            kbox_fd_table_insert_at(&t, vfd, j, 0);
+
+            /* linear congruential generator to prevent caching */
+            host_fd = (16645 * host_fd + 10139) % 65536;
+            kbox_fd_table_set_host_fd(&t, vfd, host_fd);
+            if (j == n / 2) {
+                target_present = host_fd;
+            }
+        }
+
+        struct timespec start, end;
+        double present_time_ns, absent_time_ns;
+
+        long sum_present = 0;
+        long sum_absent = 0;
+
+        clock_gettime(CLOCK_MONOTONIC, &start);
+        for (int k = 0; k < PERF_ITERATIONS; k++) {
+            sum_present += kbox_fd_table_find_by_host_fd(&t, target_present);
+        }
+        clock_gettime(CLOCK_MONOTONIC, &end);
+        present_time_ns = time_diff_ns(&start, &end) / PERF_ITERATIONS;
+
+        clock_gettime(CLOCK_MONOTONIC, &start);
+        for (int k = 0; k < PERF_ITERATIONS; k++) {
+            sum_absent += kbox_fd_table_find_by_host_fd(&t, target_absent);
+        }
+        clock_gettime(CLOCK_MONOTONIC, &end);
+        absent_time_ns = time_diff_ns(&start, &end) / PERF_ITERATIONS;
+
+        printf("N = %-5d | Present: %6.2f ns/op | Absent: %6.2f ns/op\n", n,
+               present_time_ns, absent_time_ns);
+
+        if (i == 0) {
+            baseline_present_ns = present_time_ns;
+            baseline_absent_ns = absent_time_ns;
+        } else {
+            /* The per-lookup cost ratio across N must stay under ~2x */
+            double present_ratio = present_time_ns / baseline_present_ns;
+            double absent_ratio = absent_time_ns / baseline_absent_ns;
+
+            ASSERT_TRUE(present_ratio < 2);
+            ASSERT_TRUE(absent_ratio < 2);
+        }
+    }
+}
+#endif
 void test_fd_table_refcount_init(void)
 {
     TEST_REGISTER(test_fd_table_multi_downgrade_regression);
+
+#ifdef KBOX_PERF_TESTS
+    PERF_REGISTER(test_fd_table_o1_characteristics);
+#endif
 }

--- a/tests/unit/test-runner.c
+++ b/tests/unit/test-runner.c
@@ -90,6 +90,7 @@ void test_pass(void)
 /* External init functions from each test file */
 /* Portable test suites (all hosts) */
 extern void test_fd_table_init(void);
+extern void test_fd_table_refcount_init(void);
 extern void test_path_init(void);
 extern void test_mount_init(void);
 extern void test_cli_init(void);
@@ -120,6 +121,7 @@ int main(int argc, char *argv[])
 
     /* Portable suites */
     test_fd_table_init();
+    test_fd_table_refcount_init();
     test_path_init();
     test_mount_init();
     test_cli_init();

--- a/tests/unit/test-runner.h
+++ b/tests/unit/test-runner.h
@@ -77,6 +77,11 @@ void test_pass(void);
     } while (0)
 #endif
 
+#ifdef KBOX_PERF_ONLY
+#define TEST_REGISTER(fn) ((void) 0)
+#define PERF_REGISTER(fn) test_register(#fn, fn)
+#else
 #define TEST_REGISTER(fn) test_register(#fn, fn)
+#endif
 
 #endif /* TEST_RUNNER_H */


### PR DESCRIPTION
(This PR is built on top of #68. Please review/merge that one first)

This PR serve as the reference for https://github.com/sysprog21/kbox/issues/38#issuecomment-4415459055

---------

Resolve test gap 3 in #38:
- Add a `check-perf` build target that compiles the unit test suite with `-O2 -DKBOX_PERF_ONLY` in a separate
binary (`test-perf`), keeping it independent from the check-unit artifact. Sanitizer and debug flags are stripped from `PERF_TEST_CFLAGS` so timings reflect optimized production code.

- Add a benchmark that exercises `kbox_fd_table_find_by_host_fd` for both present and absent host FDs across table sizes {64, 256, 1024, 4096, 16384} and asserts that per-lookup latency stays within 2x of the N=64 baseline.

### Results
```
--- O(1) Characteristic Perf Test ---
N = 64    | Present:   1.65 ns/op | Absent:   1.39 ns/op
N = 256   | Present:   1.87 ns/op | Absent:   1.38 ns/op
N = 1024  | Present:   1.60 ns/op | Absent:   1.29 ns/op
N = 4096  | Present:   1.63 ns/op | Absent:   1.31 ns/op
N = 16384 | Present:   1.59 ns/op | Absent:   1.39 ns/op
ok
```
The lookup time is flat across all table sizes — present lookups stay in the 1.59–1.87 ns range and absent lookups stay in the 1.29–1.39 ns range regardless of whether the table has 64 or 16384 entries, adhering to O(1) signature.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a perf-only test runner (`check-perf`) and an O(1) reverse-lookup benchmark for the FD table, plus a fix that correctly downgrades `MULTI` mappings when aliases close. Covers test gap 3 in #38 and runs in CI without sanitizers to reflect production timing.

- **New Features**
  - `make check-perf`: builds a separate `tests/unit/test-perf` with `-O2 -DKBOX_PERF_ONLY` (no sanitizers/debug) so only perf benchmarks run; included in `make check` and a new CI `perf-tests` job.
  - O(1) benchmark for `kbox_fd_table_find_by_host_fd` across {64, 256, 1024, 4096, 16384}; asserts present/absent lookups stay ≤2x the N=64 baseline.

- **Bug Fixes**
  - Add `host_fd_refs[]` and update `rev_host_set/clear` to maintain counts and downgrade from `MULTI` to the surviving VFD when one alias remains; counters initialized in `kbox_fd_table_init`.
  - New regression test (`test-fd-table-refcount.c`) ensures reverse lookup returns the survivor after other aliases close.

<sup>Written for commit 00005425cdc606f6d58f920c68ddc872d230fdd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/kbox/pull/70?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

